### PR TITLE
small fixes

### DIFF
--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -47,8 +47,7 @@ export ScalarOperator,
        DiagonalOperator,
        AffineOperator,
        FunctionOperator,
-       TensorProductOperator,
-       ⊗
+       TensorProductOperator
 
 export update_coefficients!,
        update_coefficients,

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -11,9 +11,10 @@ import Lazy: @forward
 import Setfield: @set!
 
 # overload
-import Base: +, -, *, /, \, ∘, ==, one, zero
-import Base: conj, iszero, inv, adjoint, transpose, size, convert, Matrix
-import LinearAlgebra: mul!, ldiv!, lmul!, rmul!, factorize, exp, Diagonal
+import Base: +, -, *, /, \, ∘, ==, one, zero, conj, exp, kron
+import Base: iszero, inv, adjoint, transpose, size, convert
+import LinearAlgebra: mul!, ldiv!, lmul!, rmul!, factorize
+import LinearAlgebra: Matrix, Diagonal
 import SparseArrays: sparse
 
 """
@@ -46,7 +47,8 @@ export ScalarOperator,
        DiagonalOperator,
        AffineOperator,
        FunctionOperator,
-       TensorProductOperator
+       TensorProductOperator,
+       ⊗
 
 export update_coefficients!,
        update_coefficients,

--- a/src/sciml.jl
+++ b/src/sciml.jl
@@ -79,7 +79,7 @@ LinearAlgebra.ldiv!(v::AbstractVector, L::MatrixOperator, u::AbstractVector) = l
 LinearAlgebra.ldiv!(L::MatrixOperator, u::AbstractVector) = ldiv!(L.A, u)
 
 for op in (
-           :+, :-, :*
+           :+, :-,
           )
 
     @eval function Base.$op(A::AbstractMatrix, L::AbstractSciMLOperator)
@@ -90,17 +90,15 @@ for op in (
         @assert size(A) == size(L)
         $op(L, MatrixOperator($op(A)))
     end
+end
 
-    @eval function Base.$op(A::UniformScaling, L::AbstractSciMLOperator)
-        @assert issquare(A)
-        N = size(A, 1)
-        $op(A.λ * IdentityOperator{N}(), $op(L))
-    end
-    @eval function Base.$op(L::AbstractSciMLOperator, A::UniformScaling)
-        @assert issquare(A)
-        N = size(A, 1)
-        $op($op(L), A.λ * IdentityOperator{N}())
-    end
+function Base.:*(A::AbstractMatrix, L::AbstractSciMLOperator)
+    @assert size(A) == size(L)
+    *(MatrixOperator(A), L)
+end
+function Base.:*(L::AbstractSciMLOperator, A::AbstractMatrix)
+    @assert size(A) == size(L)
+    *(L, MatrixOperator(A))
 end
 
 """ Diagonal Operator """

--- a/src/sciml.jl
+++ b/src/sciml.jl
@@ -499,13 +499,23 @@ function TensorProductOperator(out, in; cache = nothing)
     TensorProductOperator(out, in, cache, isset)
 end
 
-⊗(ops...) = TensorProductOperator(ops...)
+# constructors
+TensorProductOperator(op::AbstractSciMLOperator) = op
+TensorProductOperator(op::AbstractMatrix) = MatrixOperator(op)
 TensorProductOperator(ops...) = reduce(TensorProductOperator, ops)
+
+# overload ⊗ (\otimes)
+⊗(ops::Union{AbstractMatrix,AbstractSciMLOperator}...) = TensorProductOperator(ops...)
+
+# convert to matrix
+Base.kron(ops::AbstractSciMLOperator...) = kron(convert.(AbstractMatrix, ops)...)
+
 function Base.convert(::Type{AbstractMatrix}, L::TensorProductOperator)
     kron(convert(AbstractMatrix, L.outer), convert(AbstractMatrix, L.inner))
 end
+
 function SparseArrays.sparse(L::TensorProductOperator)
-    kron(sparse(L.outer) ⊗ sparse(L.inner))
+    kron(sparse(L.outer), sparse(L.inner))
 end
 
 #LinearAlgebra.opnorm(L::TensorProductOperator) = prod(opnorm, L.ops)

--- a/test/sciml.jl
+++ b/test/sciml.jl
@@ -219,7 +219,6 @@ end
     DD = Diagonal(AbstractSciMLOperator[D1, D2])
 
     op = TT' * DD * TT
-
     op = cache_operator(op, u)
 
     v=rand(N2); @test mul!(v, op, u) ≈ op * u


### PR DESCRIPTION
- clarify TensorProductOperator constructor.
- fixed overloads now,  `kron(...) isa AbstractMatrix`, `\otimes(...) isa TensorProductOperator`
- remove redundant +,-,*(SciMLOperator, UniformScaling) methods
- ~exporting `\otimes` as it does not conflict with anything in Base or LinearAlgebra~