### PR TITLE
Faster TensorProductOperator

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -102,7 +102,6 @@ function Base.zero(A::AbstractSciMLOperator)
     NullOperator{N}()
 end
 
-# TODO sparse diagonal
 Base.convert(::Type{AbstractMatrix}, ::NullOperator{N}) where{N} = Diagonal(zeros(Bool, N))
 
 # traits
@@ -230,7 +229,7 @@ end
 for op in (:-, :+)
     @eval Base.$op(α::ScalarOperator, x::Number) = $op(α.val, x)
     @eval Base.$op(x::Number, α::ScalarOperator) = $op(x, α.val)
-    @eval Base.$op(x::ScalarOperator, y::ScalarOperator) = $op(x.val, y.val) # TODO - lazy compose instead?
+    @eval Base.$op(x::ScalarOperator, y::ScalarOperator) = $op(x.val, y.val) # TODO - lazy sum instead?
 end
 
 LinearAlgebra.lmul!(α::ScalarOperator, u::AbstractVecOrMat) = lmul!(α.val, u)

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -200,8 +200,8 @@ function Base.adjoint(α::ScalarOperator) # TODO - test
     ScalarOperator(val; update_func=update_func)
 end
 Base.transpose(α::ScalarOperator) = α
-Base.one(::Type{AbstractSciMLOperator}) = ScalarOperator(true)
-Base.zero(::Type{AbstractSciMLOperator}) = ScalarOperator(false)
+Base.one(::Type{<:AbstractSciMLOperator}) = ScalarOperator(true)
+Base.zero(::Type{<:AbstractSciMLOperator}) = ScalarOperator(false)
 
 getops(α::ScalarOperator) = (α.val,)
 islinear(L::ScalarOperator) = true

--- a/src/sciml.jl
+++ b/src/sciml.jl
@@ -610,6 +610,7 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::Ab
 
     # V .= U * B' <===> V' .= B * C'
     if k>1
+        # TODO - avoid ops if L.outer is IdentityOperator
         C1 = _reshape(C1, (mi, no, k))
         permutedims!(C2, C1, perm)
         C2 = _reshape(C2, (no, mi*k))

--- a/src/sciml.jl
+++ b/src/sciml.jl
@@ -618,7 +618,7 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::Ab
         permutedims!(V, C3, perm)
     else
         V  = _reshape(v, (mi, mo))
-        C1 = _reshape(C, (mi, no))
+        C1 = _reshape(C1, (mi, no))
         mul!(transpose(V), L.outer, transpose(C1))
     end
 
@@ -643,7 +643,7 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::Ab
     """
 
     # C .= A * U
-    mul!(C, L.inner, U)
+    mul!(C1, L.inner, U)
 
     # V = α(C * B') + β(V)
     if k>1
@@ -654,8 +654,8 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::Ab
             mul!(transpose(V[:,:,i]), L.outer, transpose(C[:,:,i]), α, β)
         end
     else
-        V = _reshape(v, (mi, mo))
-        C = _reshape(C, (mi, no))
+        V  = _reshape(v , (mi, mo))
+        C1 = _reshape(C1, (mi, no))
         mul!(transpose(V), L.outer, transpose(C), α, β)
     end
 
@@ -680,7 +680,7 @@ function LinearAlgebra.ldiv!(v::AbstractVecOrMat, L::TensorProductOperator, u::A
     """
 
     # C .= A \ U
-    ldiv!(C, L.inner, U)
+    ldiv!(C1, L.inner, U)
 
     # V .= C / B' <===> V' .= B \ C'
     if k>1
@@ -692,9 +692,9 @@ function LinearAlgebra.ldiv!(v::AbstractVecOrMat, L::TensorProductOperator, u::A
         V  = _reshape(v , (mi, mo, k))
         permutedims!(V, C3, perm)
     else
-        V = _reshape(v, (mi, mo))
-        C = _reshape(C, (mi, no))
-        ldiv!(transpose(V), L.outer, transpose(C))
+        V  = _reshape(v , (mi, mo))
+        C1 = _reshape(C1, (mi, no))
+        ldiv!(transpose(V), L.outer, transpose(C1))
     end
 
     v

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,15 +12,6 @@ _vec(a::AbstractVector) = a
 _vec(a::AbstractArray) = _reshape(a,(length(a),))
 _vec(a::ReshapedArray) = _vec(a.parent)
 
-function _view(a, dims::NTuple{D,Int}) where{D}
-    # just one Colon -> _vec
-    all(dim -> isa(dim, Colon), dims) && return a
-    dims == size(a) && return a
-    length(a) == prod(dims) && return a
-
-    view(a, dims...)
-end
-
 function _mat_sizes(L::AbstractSciMLOperator, u::AbstractArray)
 
     size_in = u isa AbstractVecOrMat ? size(u) : begin

--- a/test/sciml.jl
+++ b/test/sciml.jl
@@ -194,7 +194,7 @@ end
     op = ⊗(A, B)
     op = cache_operator(op, u)
     v=rand(N1*N2); @test ldiv!(v, op, u) ≈ AB \ u
-#   v=copy(u);     @test ldiv!(op, u)    ≈ AB \ v
+    v=copy(u);     @test ldiv!(op, u)    ≈ AB \ v
 end
 
 @testset "Operator Algebra" begin
@@ -221,6 +221,6 @@ end
     op = cache_operator(op, u)
 
     v=rand(N2,K); @test mul!(v, op, u) ≈ op * u
-#   v=rand(N2,K); w=copy(v); @test mul!(v, op, u, α, β) ≈ α*(op * u) + β * w
+    v=rand(N2,K); w=copy(v); @test mul!(v, op, u, α, β) ≈ α*(op * u) + β * w
 end
 #

--- a/test/sciml.jl
+++ b/test/sciml.jl
@@ -181,8 +181,8 @@ end
     v2=rand(M2,K); @test mul!(v2, opAB , u2) ≈ AB  * u2
     v3=rand(M3,K); @test mul!(v3, opABC, u3) ≈ ABC * u3
 
-    v2=rand(M2,K); w2=copy(v2); @test mul!(v2, opAB , u2, α, β) ≈ α*AB *u2 + β*w2
-    v3=rand(M3,K); w3=copy(v3); @test mul!(v3, opABC, u3, α, β) ≈ α*ABC*u3 + β*w3
+#   v2=rand(M2,K); w2=copy(v2); @test mul!(v2, opAB , u2, α, β) ≈ α*AB *u2 + β*w2
+#   v3=rand(M3,K); w3=copy(v3); @test mul!(v3, opABC, u3, α, β) ≈ α*ABC*u3 + β*w3
 
     N1 = 8
     N2 = 12
@@ -194,7 +194,7 @@ end
     op = ⊗(A, B)
     op = cache_operator(op, u)
     v=rand(N1*N2); @test ldiv!(v, op, u) ≈ AB \ u
-    v=copy(u);     @test ldiv!(op, u)    ≈ AB \ v
+#   v=copy(u);     @test ldiv!(op, u)    ≈ AB \ v
 end
 
 @testset "Operator Algebra" begin
@@ -221,6 +221,6 @@ end
     op = cache_operator(op, u)
 
     v=rand(N2,K); @test mul!(v, op, u) ≈ op * u
-    v=rand(N2,K); w=copy(v); @test mul!(v, op, u, α, β) ≈ α*(op * u) + β * w
+#   v=rand(N2,K); w=copy(v); @test mul!(v, op, u, α, β) ≈ α*(op * u) + β * w
 end
 #

--- a/test/sciml.jl
+++ b/test/sciml.jl
@@ -1,7 +1,7 @@
 using SciMLOperators, LinearAlgebra
 using Random
 
-using SciMLOperators: AbstractSciMLOperator, InvertibleOperator, ⊗
+using SciMLOperators: InvertibleOperator, ⊗
 
 Random.seed!(0)
 N = 8

--- a/test/sciml.jl
+++ b/test/sciml.jl
@@ -214,8 +214,8 @@ end
     D1  = DiagonalOperator(rand(N2))
     D2  = DiagonalOperator(rand(N2))
 
-    TT = AbstractSciMLOperator[T1, T2]
-    DD = Diagonal(AbstractSciMLOperator[D1, D2])
+    TT = [T1, T2]
+    DD = Diagonal([D1, D2])
 
     op = TT' * DD * TT
     op = cache_operator(op, u)

--- a/test/sciml.jl
+++ b/test/sciml.jl
@@ -181,8 +181,8 @@ end
     v2=rand(M2,K); @test mul!(v2, opAB , u2) ≈ AB  * u2
     v3=rand(M3,K); @test mul!(v3, opABC, u3) ≈ ABC * u3
 
-#   v2=rand(M2,K); w2=copy(v2); @test mul!(v2, opAB , u2, α, β) ≈ α*AB *u2 + β*w2
-#   v3=rand(M3,K); w3=copy(v3); @test mul!(v3, opABC, u3, α, β) ≈ α*ABC*u3 + β*w3
+    v2=rand(M2,K); w2=copy(v2); @test mul!(v2, opAB , u2, α, β) ≈ α*AB *u2 + β*w2
+    v3=rand(M3,K); w3=copy(v3); @test mul!(v3, opABC, u3, α, β) ≈ α*ABC*u3 + β*w3
 
     N1 = 8
     N2 = 12


### PR DESCRIPTION
fixes https://github.com/SciML/SciMLOperators.jl/issues/58

```julia
using SciMLOperators, LinearAlgebra
using BenchmarkTools

A = TensorProductOperator(rand(12,12), rand(12,12), rand(12,12))

u = rand(12^3, 100)
v = rand(12^3, 100)

A = cache_operator(A, u)

mul!(v, A, u) # dunny
@btime mul!($v, $A, $u); # 4.510 ms (17 allocations: 31.36 KiB)
```

```julia
julia> versioninfo()
Julia Version 1.8.0-rc1
Commit 6368fdc6565 (2022-05-27 18:33 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin21.4.0)
  CPU: 4 × Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, broadwell)
  Threads: 4 on 4 virtual cores
Environment:
  JULIA_NUM_PRECOMPILE_TASKS = 4
  JULIA_DEPOT_PATH = /Users/vp/.julia
  JULIA_NUM_THREADS = 4
```

this is on par with linearmaps in terms of speed, and miles ahed in terms of allocations. ref https://github.com/SciML/SciMLOperators.jl/issues/58#issuecomment-1158944896