### PR TITLE
resolve method ambiguity

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -315,6 +315,16 @@ Base.:+(A::AbstractSciMLOperator, B::AddedOperator) = AddedOperator(A, B.ops...)
 Base.:+(A::AddedOperator, B::AbstractSciMLOperator) = AddedOperator(A.ops..., B)
 Base.:+(A::AddedOperator, B::AddedOperator) = AddedOperator(A.ops..., B.ops...)
 
+function Base.:+(A::AddedOperator, Z::NullOperator)
+    @assert size(A) == size(Z)
+    A
+end
+
+function Base.:+(Z::NullOperator, A::AddedOperator)
+    @assert size(A) == size(Z)
+    A
+end
+
 Base.:-(A::AbstractSciMLOperator, B::AbstractSciMLOperator) = AddedOperator(A, -B)
 
 for op in (


### PR DESCRIPTION
ERROR:
```julia
  +(A::SciMLOperators.AbstractSciMLOperator, ::NullOperator{N}) where N in SciMLOperators at /Us
ers/vp/.julia/dev/SciMLOperators/src/basic.jl:165
  +(A::SciMLOperators.AddedOperator, B::SciMLOperators.AbstractSciMLOperator) in SciMLOperators 
at /Users/vp/.julia/dev/SciMLOperators/src/basic.jl:315
Possible fix, define
  +(::SciMLOperators.AddedOperator, ::NullOperator{N}) where N
```