### PR TITLE
using `Base.ReshapedArray` is unnecessary

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 authors = ["xtalax <alex.lemony@gmail.com>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -50,12 +50,12 @@ function LinearAlgebra.ishermitian(L::BatchedDiagonalOperator)
     if isreal(L)
         true
     else
-        d = _vec(L.diag)
+        d = vec(L.diag)
         D = Diagonal(d)
         ishermitian(d)
     end
 end
-LinearAlgebra.isposdef(L::BatchedDiagonalOperator) = isposdef(Diagonal(_vec(L.diag)))
+LinearAlgebra.isposdef(L::BatchedDiagonalOperator) = isposdef(Diagonal(vec(L.diag)))
 
 isconstant(L::BatchedDiagonalOperator) = L.update_func == DEFAULT_UPDATE_FUNC
 issquare(L::BatchedDiagonalOperator) = true
@@ -72,9 +72,9 @@ Base.:*(L::BatchedDiagonalOperator, u::AbstractVecOrMat) = L.diag .* u
 Base.:\(L::BatchedDiagonalOperator, u::AbstractVecOrMat) = L.diag .\ u
 
 function LinearAlgebra.mul!(v::AbstractVecOrMat, L::BatchedDiagonalOperator, u::AbstractVecOrMat)
-    V = _vec(v)
-    U = _vec(u)
-    d = _vec(L.diag)
+    V = vec(v)
+    U = vec(u)
+    d = vec(L.diag)
     D = Diagonal(d)
     mul!(V, D, U)
 
@@ -82,9 +82,9 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::BatchedDiagonalOperator, u::
 end
 
 function LinearAlgebra.mul!(v::AbstractVecOrMat, L::BatchedDiagonalOperator, u::AbstractVecOrMat, α, β)
-    V = _vec(v)
-    U = _vec(u)
-    d = _vec(L.diag)
+    V = vec(v)
+    U = vec(u)
+    d = vec(L.diag)
     D = Diagonal(d)
     mul!(V, D, U, α, β)
 
@@ -92,9 +92,9 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::BatchedDiagonalOperator, u::
 end
 
 function LinearAlgebra.ldiv!(v::AbstractVecOrMat, L::BatchedDiagonalOperator, u::AbstractVecOrMat)
-    V = _vec(v)
-    U = _vec(u)
-    d = _vec(L.diag)
+    V = vec(v)
+    U = vec(u)
+    d = vec(L.diag)
     D = Diagonal(d)
     ldiv!(V, D, U)
 
@@ -102,8 +102,8 @@ function LinearAlgebra.ldiv!(v::AbstractVecOrMat, L::BatchedDiagonalOperator, u:
 end
 
 function LinearAlgebra.ldiv!(L::BatchedDiagonalOperator, u::AbstractVecOrMat)
-    U = _vec(u)
-    d = _vec(L.diag)
+    U = vec(u)
+    d = vec(L.diag)
     D = Diagonal(d)
     ldiv!(D, U)
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -57,7 +57,7 @@ function cache_operator(L::AbstractSciMLOperator, u::AbstractArray)
 
     @assert s[1] == n "Dimension mismatch"
 
-    U = _reshape(u, (n, k))
+    U = reshape(u, (n, k))
     L = cache_operator(L, U)
     L
 end

--- a/src/left.jl
+++ b/src/left.jl
@@ -94,7 +94,7 @@ for (op, LType, VType) in (
                             )
 
     @eval function cache_internals(L::$LType, u::AbstractVecOrMat)
-        @set! L.L = cache_operator(L.L, _reshape(u, size(L,1)))
+        @set! L.L = cache_operator(L.L, reshape(u, size(L,1)))
         L
     end
 

--- a/src/multidim.jl
+++ b/src/multidim.jl
@@ -14,10 +14,10 @@ for op in (
             (size(L, 1), size(u)[2:end]...,)
         end
 
-        uu = _reshape(u, sizes[1])
+        uu = reshape(u, sizes[1])
         vv = $op(L, uu)
 
-        _reshape(vv, sizev)
+        reshape(vv, sizev)
     end
 end
 
@@ -26,8 +26,8 @@ function LinearAlgebra.mul!(v::AbstractArray, L::AbstractSciMLLinearOperator, u:
 
     sizes = _mat_sizes(L, u)
 
-    uu = _reshape(u, sizes[1])
-    vv = _reshape(v, sizes[2])
+    uu = reshape(u, sizes[1])
+    vv = reshape(v, sizes[2])
 
     mul!(vv, L, uu)
 
@@ -39,8 +39,8 @@ function LinearAlgebra.mul!(v::AbstractArray, L::AbstractSciMLLinearOperator, u:
 
     sizes = _mat_sizes(L, u)
 
-    uu = _reshape(u, sizes[1])
-    vv = _reshape(v, sizes[2])
+    uu = reshape(u, sizes[1])
+    vv = reshape(v, sizes[2])
 
     mul!(vv, L, uu, α, β)
 
@@ -52,8 +52,8 @@ function LinearAlgebra.ldiv!(v::AbstractArray, L::AbstractSciMLLinearOperator, u
 
     sizes = _mat_sizes(L, u)
 
-    uu = _reshape(u, sizes[1])
-    vv = _reshape(v, sizes[2])
+    uu = reshape(u, sizes[1])
+    vv = reshape(v, sizes[2])
 
     ldiv!(vv, L, uu)
 
@@ -65,7 +65,7 @@ function LinearAlgebra.ldiv!(L::AbstractSciMLLinearOperator, u::AbstractArray)
 
     sizes = _mat_sizes(L, u)
 
-    uu = _reshape(u, sizes[1])
+    uu = reshape(u, sizes[1])
 
     ldiv!(L, uu)
 

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -96,12 +96,12 @@ function Base.:*(L::TensorProductOperator, u::AbstractVecOrMat)
     m , n  = size(L)
     k = size(u, 2)
 
-    U = _reshape(u, (ni, no*k))
+    U = reshape(u, (ni, no*k))
     C = L.inner * U
 
     V = outer_mul(L, u, C)
 
-    u isa AbstractMatrix ? _reshape(V, (m, k)) : _reshape(V, (m,))
+    u isa AbstractMatrix ? reshape(V, (m, k)) : reshape(V, (m,))
 end
 
 function Base.:\(L::TensorProductOperator, u::AbstractVecOrMat)
@@ -110,12 +110,12 @@ function Base.:\(L::TensorProductOperator, u::AbstractVecOrMat)
     m , n  = size(L)
     k = size(u, 2)
 
-    U = _reshape(u, (ni, no*k))
+    U = reshape(u, (ni, no*k))
     C = L.inner \ U
 
     V = outer_div(L, u, C)
 
-    u isa AbstractMatrix ? _reshape(V, (m, k)) : _reshape(V, (m,))
+    u isa AbstractMatrix ? reshape(V, (m, k)) : reshape(V, (m,))
 end
 
 function cache_self(L::TensorProductOperator, u::AbstractVecOrMat)
@@ -141,7 +141,7 @@ function cache_internals(L::TensorProductOperator, u::AbstractVecOrMat) where{D}
     _ , no = size(L.outer)
     k = size(u, 2)
 
-    uinner = _reshape(u, (ni, no*k))
+    uinner = reshape(u, (ni, no*k))
     uouter = L.cache[2]
 
     @set! L.inner = cache_operator(L.inner, uinner)
@@ -158,7 +158,7 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::Ab
     k = size(u, 2)
 
     C1, C2, C3, _ = L.cache
-    U = _reshape(u, (ni, no*k))
+    U = reshape(u, (ni, no*k))
 
     """
         v .= kron(B, A) * u
@@ -183,7 +183,7 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::Ab
     k = size(u, 2)
 
     C1, C2, C3, c4 = L.cache
-    U = _reshape(u, (ni, no*k))
+    U = reshape(u, (ni, no*k))
 
     """
         v .= α * kron(B, A) * u + β * v
@@ -208,7 +208,7 @@ function LinearAlgebra.ldiv!(v::AbstractVecOrMat, L::TensorProductOperator, u::A
     k = size(u, 2)
 
     C1, C2, C3, _ = L.cache
-    U = _reshape(u, (ni, no*k))
+    U = reshape(u, (ni, no*k))
 
     """
         v .= kron(B, A) ldiv u
@@ -232,7 +232,7 @@ function LinearAlgebra.ldiv!(L::TensorProductOperator, u::AbstractVecOrMat)
     no = size(L.outer, 1)
     k  = size(u, 2)
 
-    U = _reshape(u, (ni, no*k))
+    U = reshape(u, (ni, no*k))
 
     """
         u .= kron(B, A) ldiv u
@@ -268,12 +268,12 @@ function outer_mul(L::TensorProductOperator, u::AbstractVecOrMat, C::AbstractVec
     mo, no = size(L.outer)
 #   m , n  = size(L)
 
-    C = _reshape(C, (mi, no, k))
+    C = reshape(C, (mi, no, k))
     C = permutedims(C, PERM)
-    C = _reshape(C, (no, mi*k))
+    C = reshape(C, (no, mi*k))
 
     V = L.outer * C
-    V = _reshape(V, (mo, mi, k))
+    V = reshape(V, (mo, mi, k))
     V = permutedims(V, PERM)
 
     V
@@ -297,20 +297,20 @@ function outer_mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::AbstractVe
     k = size(u, 2)
 
     if k == 1
-        V  = _reshape(v, (mi, mo))
-        C1 = _reshape(C1, (mi, no))
+        V  = reshape(v, (mi, mo))
+        C1 = reshape(C1, (mi, no))
         mul!(transpose(V), L.outer, transpose(C1))
         return v
     end
 
     _, C2, C3, _ = L.cache
 
-    C1 = _reshape(C1, (mi, no, k))
+    C1 = reshape(C1, (mi, no, k))
     permutedims!(C2, C1, PERM)
-    C2 = _reshape(C2, (no, mi*k))
+    C2 = reshape(C2, (no, mi*k))
     mul!(C3, L.outer, C2)
-    C3 = _reshape(C3, (mo, mi, k))
-    V  = _reshape(v , (mi, mo, k))
+    C3 = reshape(C3, (mo, mi, k))
+    V  = reshape(v , (mi, mo, k))
     permutedims!(V, C3, PERM)
 
     v
@@ -322,7 +322,7 @@ function outer_mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::AbstractVe
     m, _ = size(L)
 
     if L.outer isa IdentityOperator
-        c1 = _reshape(C1, (m, k))
+        c1 = reshape(C1, (m, k))
         axpby!(α, c1, β, v)
         return v
     elseif L.outer isa ScaledOperator
@@ -336,20 +336,20 @@ function outer_mul!(v::AbstractVecOrMat, L::TensorProductOperator, u::AbstractVe
     k = size(u, 2)
 
     if k == 1
-        V  = _reshape(v, (mi, mo))
-        C1 = _reshape(C1, (mi, no))
+        V  = reshape(v, (mi, mo))
+        C1 = reshape(C1, (mi, no))
         mul!(transpose(V), L.outer, transpose(C1), α, β)
         return v
     end
 
     _, C2, C3, c4 = L.cache
 
-    C1 = _reshape(C1, (mi, no, k))
+    C1 = reshape(C1, (mi, no, k))
     permutedims!(C2, C1, PERM)
-    C2 = _reshape(C2, (no, mi*k))
+    C2 = reshape(C2, (no, mi*k))
     mul!(C3, L.outer, C2)
-    C3 = _reshape(C3, (mo, mi, k))
-    V  = _reshape(v , (mi, mo, k))
+    C3 = reshape(C3, (mo, mi, k))
+    V  = reshape(v , (mi, mo, k))
     copy!(c4, v)
     permutedims!(V, C3, PERM)
     axpby!(β, c4, α, v)
@@ -373,12 +373,12 @@ function outer_div(L::TensorProductOperator, u::AbstractVecOrMat, C::AbstractVec
     mo, no = size(L.outer)
 #   m , n  = size(L)
 
-    C = _reshape(C, (mi, no, k))
+    C = reshape(C, (mi, no, k))
     C = permutedims(C, PERM)
-    C = _reshape(C, (no, mi*k))
+    C = reshape(C, (no, mi*k))
 
     V = L.outer \ C
-    V = _reshape(V, (mo, mi, k))
+    V = reshape(V, (mo, mi, k))
     V = permutedims(V, PERM)
 
     V
@@ -402,20 +402,20 @@ function outer_div!(v::AbstractVecOrMat, L::TensorProductOperator, u::AbstractVe
     k = size(u, 2)
 
     if k == 1
-        V  = _reshape(v, (mi, mo))
-        C1 = _reshape(C1, (mi, no))
+        V  = reshape(v, (mi, mo))
+        C1 = reshape(C1, (mi, no))
         ldiv!(transpose(V), L.outer, transpose(C1))
         return v
     end
 
     _, C2, C3, _ = L.cache
 
-    C1 = _reshape(C1, (mi, no, k))
+    C1 = reshape(C1, (mi, no, k))
     permutedims!(C2, C1, PERM)
-    C2 = _reshape(C2, (no, mi*k))
+    C2 = reshape(C2, (no, mi*k))
     ldiv!(C3, L.outer, C2)
-    C3 = _reshape(C3, (mo, mi, k))
-    V  = _reshape(v , (mi, mo, k))
+    C3 = reshape(C3, (mo, mi, k))
+    V  = reshape(v , (mi, mo, k))
     permutedims!(V, C3, PERM)
 
     v
@@ -435,7 +435,7 @@ function outer_div!(L::TensorProductOperator, u::AbstractVecOrMat)
 #   m , n  = size(L)
     k = size(u, 2)
 
-    U = _reshape(u, (ni, no*k))
+    U = reshape(u, (ni, no*k))
 
     if k == 1
         ldiv!(L.outer, transpose(U))
@@ -444,8 +444,8 @@ function outer_div!(L::TensorProductOperator, u::AbstractVecOrMat)
 
     C = first(L.cache)
 
-    U = _reshape(U, (ni, no, k))
-    C = _reshape(C, (no, ni, k))
+    U = reshape(U, (ni, no, k))
+    C = reshape(C, (no, ni, k))
     permutedims!(C, U, PERM)
     ldiv!(L.outer, C)
     permutedims!(U, C, PERM)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,4 @@
 #
-_vec(a) = vec(a)
-_reshape(a, dims::NTuple{D,Int}) where{D} = reshape(a, dims)
-
 function _mat_sizes(L::AbstractSciMLOperator, u::AbstractArray)
     m, n = size(L)
     nk = length(u)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,17 +1,17 @@
 #
 """ use Base.ReshapedArray """
 _reshape(a, dims::NTuple{D,Int}) where{D} = reshape(a,dims)
-_reshape(a::ReshapedArray, dims::NTuple{D,Int}) where{D} = _reshape(a.parent, dims)
-
-function _reshape(a::AbstractArray, dims::NTuple{D,Int}) where{D}
-    @assert prod(dims) == length(a) "cannot reshape array of size $(size(a)) to size $dims"
-    dims == size(a) && return a
-    ReshapedArray(a, dims, ())
-end
+#_reshape(a::ReshapedArray, dims::NTuple{D,Int}) where{D} = _reshape(a.parent, dims)
+#
+#function _reshape(a::AbstractArray, dims::NTuple{D,Int}) where{D}
+#    @assert prod(dims) == length(a) "cannot reshape array of size $(size(a)) to size $dims"
+#    dims == size(a) && return a
+#    ReshapedArray(a, dims, ())
+#end
 
 _vec(a) = vec(a)
-_vec(a::AbstractVector) = a
-_vec(a::AbstractArray) = _reshape(a,(length(a),))
+#_vec(a::AbstractVector) = a
+#_vec(a::AbstractArray) = _reshape(a,(length(a),))
 
 function _mat_sizes(L::AbstractSciMLOperator, u::AbstractArray)
     m, n = size(L)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,17 +1,6 @@
 #
-""" use Base.ReshapedArray """
-_reshape(a, dims::NTuple{D,Int}) where{D} = reshape(a,dims)
-#_reshape(a::ReshapedArray, dims::NTuple{D,Int}) where{D} = _reshape(a.parent, dims)
-#
-#function _reshape(a::AbstractArray, dims::NTuple{D,Int}) where{D}
-#    @assert prod(dims) == length(a) "cannot reshape array of size $(size(a)) to size $dims"
-#    dims == size(a) && return a
-#    ReshapedArray(a, dims, ())
-#end
-
 _vec(a) = vec(a)
-#_vec(a::AbstractVector) = a
-#_vec(a::AbstractArray) = _reshape(a,(length(a),))
+_reshape(a, dims::NTuple{D,Int}) where{D} = reshape(a, dims)
 
 function _mat_sizes(L::AbstractSciMLOperator, u::AbstractArray)
     m, n = size(L)


### PR DESCRIPTION
fix https://github.com/SciML/SciMLOperators.jl/issues/91

just to make sure, im comparing performance on `benchmark/tensor.jl` with `_reshape, _vec`, and without.

with `_reshape, _vec` - https://github.com/SciML/SciMLOperators.jl/pull/92/commits/f2b7fe9045481d792826b2bad7a362ce35d6fde3
```julia
[vp@MBP benchmarks]:jl
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0-rc3 (2022-07-13)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> versioninfo()
Julia Version 1.8.0-rc3
Commit 33f19bcbd25 (2022-07-13 19:10 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin21.4.0)
  CPU: 4 × Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, broadwell)
  Threads: 4 on 4 virtual cores
Environment:
  JULIA_NUM_PRECOMPILE_TASKS = 4
  JULIA_DEPOT_PATH = /Users/vp/.julia
  JULIA_NUM_THREADS = 4

julia> include("tensor.jl")
[ Info: Precompiling SciMLOperators [c0aeaf25-5076-4817-a8d5-81caf7dfa961]
┌ Warning: Replacing docs for `SciMLOperators.AbstractSciMLOperator :: Union{}` in module `SciMLOperators`
└ @ Base.Docs docs/Docs.jl:240
#===============================#
2D Tensor Products
#===============================#
⊗(A, B)
  82.031 μs (7 allocations: 304 bytes)
⊗(I, B)
  29.813 μs (1 allocation: 32 bytes)
⊗(A, I)
  66.211 μs (7 allocations: 304 bytes)
#===============================#
3D Tensor Products
#===============================#
⊗(⊗(A, B), C)
  3.453 ms (13 allocations: 576 bytes)
⊗(A, ⊗(B, C))
  3.479 ms (15 allocations: 672 bytes)
#===============================#
```