### PR TITLE
updated README and make.jl to sciml doc standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # SciMLOperators.jl
 
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](http://scimloperators.sciml.ai/stable/)
-[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/dev/modules/SciMLOperators/)
+[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/SciMLOperators/stable)
 
 [![codecov](https://codecov.io/gh/SciML/SciMLOperators.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/SciMLOperators.jl)
 [![Build Status](https://github.com/SciML/SciMLOperators.jl/workflows/CI/badge.svg)](https://github.com/SciML/SciMLOperators.jl/actions?query=workflow%3ACI)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ makedocs(
     clean=true,doctest=false,
     format = Documenter.HTML(analytics = "UA-90474609-3",
                              assets = ["assets/favicon.ico"],
-                             canonical="https://scimlbase.sciml.ai/stable/"),
+                             canonical="https://docs.sciml.ai/SciMLOperators/stable"),
     pages=pages
 )
 


### PR DESCRIPTION
I updated the docs as per the new Sciml doc specs.

NOTE:
I noticed in `make.jl` that the canonical link was originally pointing to `SciMLBase`, 
https://scimlbase.sciml.ai/stable/

That seems like a possible error to me, so I replaced it with the direct SciMLOperators link, which works. If I made an error in judgement, please let me know and I can revert that particular change. 
 