### PR TITLE
Add missing lazy factorizations for scaled operators and tensor operators

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -244,6 +244,8 @@ end
 # getindex
 Base.getindex(L::ScaledOperator, i::Int) = L.coeff * L.L[i]
 Base.getindex(L::ScaledOperator, I::Vararg{Int, N}) where {N} = L.λ * L.L[I...]
+
+factorize(L::ScaledOperator) = L.λ * factorize(L.L)
 for fact in (
              :lu, :lu!,
              :qr, :qr!,

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -89,6 +89,8 @@ has_mul!(L::TensorProductOperator) = has_mul!(L.outer) & has_mul!(L.inner)
 has_ldiv(L::TensorProductOperator) = has_ldiv(L.outer) & has_ldiv(L.inner)
 has_ldiv!(L::TensorProductOperator) = has_ldiv!(L.outer) & has_ldiv!(L.inner)
 
+factorize(L::TensorProductOperator) = TensorProductOperator(factorize(L.outer), factorize(L.inner))
+
 # operator application
 function Base.:*(L::TensorProductOperator, u::AbstractVecOrMat)
     _ , ni = size(L.inner)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -98,8 +98,16 @@ end
 
     op = ScaledOperator(α, MatrixOperator(A))
 
-    @test op * u       ≈     α * A * u
+    @test op isa ScaledOperator
+
+    @test α * A * u ≈ op * u
     @test (β * op) * u ≈ β * α * A * u
+
+    opF = factorize(op)
+
+    @test opF isa ScaledOperator
+
+    @test α * A  ≈ convert(AbstractMatrix, op) ≈ convert(AbstractMatrix, opF)
 
     v=rand(N,K); @test mul!(v, op, u) ≈ α * A * u
     v=rand(N,K); w=copy(v); @test mul!(v, op, u, a, b) ≈ a*(α*A*u) + b*w

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -166,8 +166,12 @@ end
     AB  = kron(A, B)
     ABC = kron(A, B, C)
 
+    # Inputs
     u2 = rand(n1*n2, K)
     u3 = rand(n1*n2*n3, K)
+    # Outputs
+    v2 = rand(m1*m2, K)
+    v3 = rand(m1*m2*m3, K)
 
     opAB  = TensorProductOperator(A, B)
     opABC = TensorProductOperator(A, B, C)
@@ -175,11 +179,20 @@ end
     @test opAB  isa TensorProductOperator
     @test opABC isa TensorProductOperator
 
-    @test convert(AbstractMatrix, opAB)  ≈ AB
-    @test convert(AbstractMatrix, opABC) ≈ ABC
+    opAB_F = factorize(opAB)
+    opABC_F = factorize(opABC)
 
-    @test opAB  * u2 ≈ AB  * u2
-    @test opABC * u3 ≈ ABC * u3
+    @test opAB_F isa TensorProductOperator
+    @test opABC_F isa TensorProductOperator
+
+    @test AB ≈ convert(AbstractMatrix, opAB) ≈ convert(AbstractMatrix, opAB_F)
+    @test ABC ≈ convert(AbstractMatrix, opABC) ≈ convert(AbstractMatrix, opABC_F)
+
+    @test AB  * u2 ≈ opAB  * u2
+    @test ABC * u3 ≈ opABC * u3
+
+    @test_broken AB \ v2 ≈ opAB \ v2 ≈ opAB_F \ v2
+    @test_broken ABC \ v3 ≈ opABC \ v3 ≈ opABC_F \ v3
 
     opAB  = cache_operator(opAB,  u2)
     opABC = cache_operator(opABC, u3)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -152,10 +152,14 @@ end
     v=copy(u); @test L(v,u,p,t) ≈ ans
 end
 
-@testset "TensorProductOperator" begin
+@testset "TensorProductOperator" begin for square in [false, true]
     m1, n1 = 3 , 5
     m2, n2 = 7 , 11
     m3, n3 = 13, 17
+
+    if square
+        n1, n2, n3 = m1, m2, m3
+    end
 
     A = rand(m1, n1)
     B = rand(m2, n2)
@@ -179,20 +183,26 @@ end
     @test opAB  isa TensorProductOperator
     @test opABC isa TensorProductOperator
 
-    opAB_F = factorize(opAB)
-    opABC_F = factorize(opABC)
+    @test AB ≈ convert(AbstractMatrix, opAB)
+    @test ABC ≈ convert(AbstractMatrix, opABC)
 
-    @test opAB_F isa TensorProductOperator
-    @test opABC_F isa TensorProductOperator
+    if square
+        opAB_F = factorize(opAB)
+        opABC_F = factorize(opABC)
 
-    @test AB ≈ convert(AbstractMatrix, opAB) ≈ convert(AbstractMatrix, opAB_F)
-    @test ABC ≈ convert(AbstractMatrix, opABC) ≈ convert(AbstractMatrix, opABC_F)
+        @test opAB_F isa TensorProductOperator
+        @test opABC_F isa TensorProductOperator
+
+        @test AB ≈ convert(AbstractMatrix, opAB_F)
+        @test ABC ≈ convert(AbstractMatrix, opABC_F)
+
+        @test AB \ v2 ≈ opAB \ v2 ≈ opAB_F \ v2
+        @test ABC \ v3 ≈ opABC \ v3 ≈ opABC_F \ v3
+    end
 
     @test AB  * u2 ≈ opAB  * u2
     @test ABC * u3 ≈ opABC * u3
 
-    @test_broken AB \ v2 ≈ opAB \ v2 ≈ opAB_F \ v2
-    @test_broken ABC \ v3 ≈ opABC \ v3 ≈ opABC_F \ v3
 
     opAB  = cache_operator(opAB,  u2)
     opABC = cache_operator(opABC, u3)
@@ -218,5 +228,5 @@ end
     op = cache_operator(op, u)
     v=rand(N1*N2); @test ldiv!(v, op, u) ≈ AB \ u
     v=copy(u);     @test ldiv!(op, u)    ≈ AB \ v
-end
+end end
 #


### PR DESCRIPTION
Just adds a couple missing lazy factorizations, in the same spirit as the existing factorization for a composed operator. When writing tests I found a few bugs with the tensor product operator itself; I fixed a couple typos but made an issue (#127) for the remaining bugs.