### PR TITLE
Fix composed operator factorization

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -511,7 +511,7 @@ has_mul!(L::ComposedOperator) = all(has_mul!, L.ops)
 has_ldiv(L::ComposedOperator) = all(has_ldiv, L.ops)
 has_ldiv!(L::ComposedOperator) = all(has_ldiv!, L.ops)
 
-factorize(L::ComposedOperator) = prod(factorize, reverse(L.ops))
+factorize(L::ComposedOperator) = prod(factorize, L.ops)
 for fact in (
              :lu, :lu!,
              :qr, :qr!,

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -157,8 +157,12 @@ end
     @test op isa ComposedOperator
     @test *(op.ops...) isa ComposedOperator
 
-    @test op * u ≈ ABCmulu
-    @test op \ u ≈ ABCdivu
+    opF = factorize(op)
+
+    @test opF isa ComposedOperator
+
+    @test ABCmulu ≈ op * u
+    @test ABCdivu ≈ op \ u ≈ opF \ u
 
     op = cache_operator(op, u)
     v=rand(N,K); @test mul!(v, op, u) ≈ ABCmulu


### PR DESCRIPTION
- The operators shouldn't be reversed in the composed operator factorization
~- The composed operator caching relies on matmuls, but when composing certain factorizations the inner ops may in fact not support matmuls. I used the size instead, which seems more robust?~