### PR TITLE
Prepare for `AdjointFactorization`, multiple dispatch

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -111,6 +111,9 @@ function DiagonalOperator(diag::AbstractVector; update_func=DEFAULT_UPDATE_FUNC)
 end
 LinearAlgebra.Diagonal(L::MatrixOperator) = MatrixOperator(Diagonal(L.A))
 
+const AdjointFact = isdefined(LinearAlgebra, :AdjointFactorization) ? LinearAlgebra.AdjointFactorization : Adjoint
+const TransposeFact = isdefined(LinearAlgebra, :TransposeFactorization) ? LinearAlgebra.TransposeFactorization : Transpose
+
 """
     InvertibleOperator(F)
 
@@ -153,13 +156,12 @@ function Base.convert(::Type{<:Factorization}, L::InvertibleOperator{T,<:Factori
     L.F
 end
 
-function Base.convert(::Type{AbstractMatrix}, L::InvertibleOperator)
-    if L.F isa Adjoint
-        convert(AbstractMatrix,L.F')'
-    else
-        convert(AbstractMatrix, L.F)
-    end
-end
+Base.convert(::Type{AbstractMatrix}, L::InvertibleOperator) =
+    convert(AbstractMatrix, L.F)
+Base.convert(::Type{AbstractMatrix}, L::InvertibleOperator{<:Any,<:Union{Adjoint,AdjointFact}}) =
+    adjoint(convert(AbstractMatrix, adjoint(L.F)))
+Base.convert(::Type{AbstractMatrix}, L::InvertibleOperator{<:Any,<:Union{Transpose,TransposeFact}}) =
+    transpose(convert(AbstractMatrix, transpose(L.F)))
 
 # traits
 Base.size(L::InvertibleOperator) = size(L.F)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -231,7 +231,12 @@ for square in [false, true] #for K in [1, K]
         v2=copy(u2); @test ldiv!(opAB_F , u2) ≈ AB  \ v2
         v3=copy(u3); @test ldiv!(opABC_F, u3) ≈ ABC \ v3
     else # TODO
-        u2=rand(N2,K); @test_broken ldiv!(u2, opAB_F , v2) ≈ AB  \ v2 # fails
+        u2=rand(N2,K); 
+        if VERSION < v"1.9-"
+            @test_broken ldiv!(u2, opAB_F , v2) ≈ AB  \ v2
+        else
+            @test ldiv!(u2, opAB_F , v2) ≈ AB  \ v2 # fails
+        end
         u3=rand(N3,K); @test_broken ldiv!(u3, opABC_F, v3) ≈ ABC \ v3 # errors
     end
 

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -235,7 +235,7 @@ for square in [false, true] #for K in [1, K]
         if VERSION < v"1.9-"
             @test_broken ldiv!(u2, opAB_F , v2) ≈ AB  \ v2
         else
-            @test ldiv!(u2, opAB_F , v2) ≈ AB  \ v2 # fails
+            @test ldiv!(u2, opAB_F , v2) ≈ AB  \ v2
         end
         u3=rand(N3,K); @test_broken ldiv!(u3, opABC_F, v3) ≈ ABC \ v3 # errors
     end


### PR DESCRIPTION
This prepares the ground for https://github.com/JuliaLang/julia/pull/46874. The const definition and the method signatures are harmless for older Julia versions. I also rearranged the `convert` functions and used multiple dispatch. I don't know why, but the changes fix a broken test on Julia v1.9, but not older.