### PR TITLE
Propagate kwargs through update_coefficients!

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -61,4 +61,4 @@ matrix-free representations, hence their support in the SciMLOperators interface
 In rare cases, an operator may be used in a context where additional state is expected to be provided
 to `update_coefficients!` beyond `u`, `p`, and `t`. In this case, the operator may accept this additional
 state through arbitrary keyword arguments to `update_coefficients!`. When the caller provides these, they will be recursively propagated downwards through composed operators just like `u`, `p`, and `t`, and provided to the operator.
-For the [premade SciMLOperators](premade_operators.md), one can specify the keyword arguments used by an operator with an `accepted_kwarg_fields` argument that defaults to an empty tuple.
+For the [premade SciMLOperators](premade_operators.md), one can specify the keyword arguments used by an operator with an `accepted_kwargs` argument that defaults to an empty tuple.

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -61,7 +61,7 @@ matrix-free representations, hence their support in the SciMLOperators interface
 In rare cases, an operator may be used in a context where additional state is expected to be provided
 to `update_coefficients!` beyond `u`, `p`, and `t`. In this case, the operator may accept this additional
 state through arbitrary keyword arguments to `update_coefficients!`. When the caller provides these, they will be recursively propagated downwards through composed operators just like `u`, `p`, and `t`, and provided to the operator.
-For the [premade SciMLOperators](premade_operators.md), one can specify the keyword arguments used by an operator with an `accepted_kwargs` argument that defaults to an empty tuple.
+For the [premade SciMLOperators](premade_operators.md), one can specify the keyword arguments used by an operator with an `accepted_kwargs` argument (by default, none are passed).
 
 In the below example, we create an operator that gleefully ignores `u`, `p`, and `t` and uses its own special scaling.
 ```@example

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -55,3 +55,10 @@ the proof to affine operators, so then ``exp(A*t)*v`` operations via Krylov meth
 affine as well, and all sorts of things. Thus affine operators have no matrix representation but they 
 are still compatible with essentially any Krylov method which would otherwise be compatible with
 matrix-free representations, hence their support in the SciMLOperators interface.
+
+## Note about keyword arguments to `update_coefficients!`
+
+In rare cases, an operator may be used in a context where additional state is expected to be provided
+to `update_coefficients!` beyond `u`, `p`, and `t`. In this case, the operator may accept this additional
+state through arbitrary keyword arguments to `update_coefficients!`. When the caller provides these, they will be recursively propagated downwards through composed operators just like `u`, `p`, and `t`, and provided to the operator.
+For the [premade SciMLOperators](premade_operators.md), one can specify the keyword arguments used by an operator with an `accepted_kwarg_fields` argument that defaults to an empty tuple.

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -62,3 +62,19 @@ In rare cases, an operator may be used in a context where additional state is ex
 to `update_coefficients!` beyond `u`, `p`, and `t`. In this case, the operator may accept this additional
 state through arbitrary keyword arguments to `update_coefficients!`. When the caller provides these, they will be recursively propagated downwards through composed operators just like `u`, `p`, and `t`, and provided to the operator.
 For the [premade SciMLOperators](premade_operators.md), one can specify the keyword arguments used by an operator with an `accepted_kwargs` argument that defaults to an empty tuple.
+
+In the below example, we create an operator that gleefully ignores `u`, `p`, and `t` and uses its own special scaling.
+```@example
+using SciMLOperators
+
+γ = ScalarOperator(0.0; update_func=(a, u, p, t; my_special_scaling) -> my_special_scaling,
+                   accepted_kwargs=(:my_special_scaling,))
+
+# Update coefficients, then apply operator
+update_coefficients!(γ, nothing, nothing, nothing; my_special_scaling=7.0)
+@show γ * [2.0]
+
+# Use operator application form
+@show γ([2.0], nothing, nothing; my_special_scaling = 5.0)
+nothing # hide
+```

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -1,6 +1,6 @@
 #
 """
-    BatchedDiagonalOperator(diag; update_func=nothing, accepted_kwarg_fields=())
+    BatchedDiagonalOperator(diag; update_func=nothing, accepted_kwargs=())
 
 Represents a time-dependent elementwise scaling (diagonal-scaling) operation.
 Acts on `AbstractArray`s of the same size as `diag`. The update function is called
@@ -15,9 +15,9 @@ struct BatchedDiagonalOperator{T,D,F} <: AbstractSciMLOperator{T}
     function BatchedDiagonalOperator(
                                      diag::AbstractArray;
                                      update_func=nothing,
-                                     accepted_kwarg_fields=()
+                                     accepted_kwargs=()
                                     )
-        _update_func = preprocess_update_func(update_func, accepted_kwarg_fields)
+        _update_func = preprocess_update_func(update_func, accepted_kwargs)
         new{
             eltype(diag),
             typeof(diag),
@@ -28,8 +28,8 @@ struct BatchedDiagonalOperator{T,D,F} <: AbstractSciMLOperator{T}
     end
 end
 
-function DiagonalOperator(u::AbstractArray; update_func=nothing, accepted_kwarg_fields=())
-    BatchedDiagonalOperator(u; update_func, accepted_kwarg_fields)
+function DiagonalOperator(u::AbstractArray; update_func=nothing, accepted_kwargs=())
+    BatchedDiagonalOperator(u; update_func, accepted_kwargs)
 end
 
 # traits

--- a/src/func.jl
+++ b/src/func.jl
@@ -208,7 +208,7 @@ function update_coefficients!(L::FunctionOperator, u, p, t; kwargs...)
 
     L.p = p
     L.t = t
-    L.kwargs = normalize_kwargs(kwargs)
+    L.kwargs = kwargs
 
     nothing
 end

--- a/src/func.jl
+++ b/src/func.jl
@@ -238,9 +238,6 @@ function Base.adjoint(L::FunctionOperator)
     traits = L.traits
     @set! traits.size = reverse(size(L))
 
-    p = L.p
-    t = L.t
-
     cache = if iscached(L)
         cache = reverse(L.cache)
     else
@@ -252,8 +249,9 @@ function Base.adjoint(L::FunctionOperator)
                      op_inverse,
                      op_adjoint_inverse,
                      traits,
-                     p,
-                     t,
+                     L.p,
+                     L.t,
+                     L.kwargs,
                      cache,
                     )
 end
@@ -280,9 +278,6 @@ function Base.inv(L::FunctionOperator)
         (p::Real) -> 1 / traits.opnorm(p)
     end
 
-    p = L.p
-    t = L.t
-
     cache = if iscached(L)
         cache = reverse(L.cache)
     else
@@ -294,8 +289,9 @@ function Base.inv(L::FunctionOperator)
                      op_inverse,
                      op_adjoint_inverse,
                      traits,
-                     p,
-                     t,
+                     L.p,
+                     L.t,
+                     L.kwargs,
                      cache,
                     )
 end

--- a/src/func.jl
+++ b/src/func.jl
@@ -176,8 +176,7 @@ function FunctionOperator(op,
                          traits,
                          p,
                          t,
-                         # automatically convert NamedTuple's to pairs 
-                         Base.Pairs{Symbol}(kwargs_for_op, keys(kwargs_for_op)),
+                         normalize_kwargs(kwargs_for_op),
                          cache
                         )
 
@@ -209,7 +208,7 @@ function update_coefficients!(L::FunctionOperator, u, p, t; kwargs...)
 
     L.p = p
     L.t = t
-    L.kwargs = kwargs
+    L.kwargs = normalize_kwargs(kwargs)
 
     nothing
 end

--- a/src/func.jl
+++ b/src/func.jl
@@ -177,7 +177,7 @@ function FunctionOperator(op,
                          p,
                          t,
                          # automatically convert NamedTuple's to pairs 
-                         pairs(kwargs_for_op),
+                         Base.Pairs{Symbol}(kwargs_for_op, keys(kwargs_for_op)),
                          cache
                         )
 

--- a/src/func.jl
+++ b/src/func.jl
@@ -192,10 +192,10 @@ function update_coefficients(L::FunctionOperator, u, p, t)
                     )
 end
 
-function update_coefficients!(L::FunctionOperator, u, p, t)
+function update_coefficients!(L::FunctionOperator, u, p, t; kwargs...)
     ops = getops(L)
     for op in ops
-        update_coefficients!(op, u, p, t)
+        update_coefficients!(op, u, p, t; kwargs...)
     end
 
     L.p = p

--- a/src/func.jl
+++ b/src/func.jl
@@ -184,9 +184,10 @@ function FunctionOperator(op,
 end
 
 function update_coefficients(L::FunctionOperator, u, p, t; kwargs...)
-    for op in getops(L)
-        op = update_coefficients(op, u, p, t; kwargs...)
-    end
+    op = update_coefficients(L.op, u, p, t; kwargs...)
+    op_adjoint = update_coefficients(L.op_adjoint, u, p, t; kwargs...)
+    op_inverse = update_coefficients(L.op_inverse, u, p, t; kwargs...)
+    op_adjoint_inverse = update_coefficients(L.op_adjoint_inverse, u, p, t; kwargs...)
 
     FunctionOperator(op,
                      op_adjoint,

--- a/src/func.jl
+++ b/src/func.jl
@@ -184,11 +184,10 @@ function FunctionOperator(op,
     ifcache ? cache_operator(L, input, output) : L
 end
 
-function update_coefficients(L::FunctionOperator, u, p, t)
-    op = update_coefficients(L.op, u, p, t)
-    op_adjoint = update_coefficients(L.op_adjoint, u, p, t)
-    op_inverse = update_coefficients(L.op_inverse, u, p, t)
-    op_adjoint_inverse = update_coefficients(L.op_adjoint_inverse, u, p, t)
+function update_coefficients(L::FunctionOperator, u, p, t; kwargs...)
+    for op in getops(L)
+        op = update_coefficients(op, u, p, t; kwargs...)
+    end
 
     FunctionOperator(op,
                      op_adjoint,
@@ -197,6 +196,7 @@ function update_coefficients(L::FunctionOperator, u, p, t)
                      L.traits,
                      p,
                      t,
+                     kwargs_for_op=kwargs,
                      L.cache
                     )
 end

--- a/src/func.jl
+++ b/src/func.jl
@@ -30,7 +30,7 @@ mutable struct FunctionOperator{iip,oop,T<:Number,F,Fa,Fi,Fai,Tr,P,Tt,K,C} <: Ab
                               traits,
                               p,
                               t,
-                              kwargs_for_op,
+                              accepted_kwargs,
                               cache
                              )
 
@@ -49,7 +49,7 @@ mutable struct FunctionOperator{iip,oop,T<:Number,F,Fa,Fi,Fai,Tr,P,Tt,K,C} <: Ab
             typeof(traits),
             typeof(p),
             typeof(t),
-            typeof(kwargs_for_op),
+            typeof(accepted_kwargs),
             typeof(cache),
            }(
              op,
@@ -59,7 +59,7 @@ mutable struct FunctionOperator{iip,oop,T<:Number,F,Fa,Fi,Fai,Tr,P,Tt,K,C} <: Ab
              traits,
              p,
              t,
-             kwargs_for_op,
+             accepted_kwargs,
              cache,
             )
     end
@@ -87,7 +87,7 @@ function FunctionOperator(op,
     FunctionOperator(op, input, output; kwargs...)
 end
 
-# TODO: document constructor and revisit design as needed (e.g. for "kwargs_for_op")
+# TODO: document constructor and revisit design as needed (e.g. for "accepted_kwargs")
 function FunctionOperator(op,
                           input::AbstractVecOrMat,
                           output::AbstractVecOrMat =  input;
@@ -102,7 +102,7 @@ function FunctionOperator(op,
 
                           p=nothing,
                           t::Union{Number,Nothing}=nothing,
-                          kwargs_for_op=(),
+                          accepted_kwargs=(),
 
                           ifcache::Bool = true,
 
@@ -176,7 +176,7 @@ function FunctionOperator(op,
                          traits,
                          p,
                          t,
-                         normalize_kwargs(kwargs_for_op),
+                         normalize_kwargs(accepted_kwargs),
                          cache
                         )
 
@@ -195,7 +195,7 @@ function update_coefficients(L::FunctionOperator, u, p, t; kwargs...)
                      L.traits,
                      p,
                      t,
-                     kwargs_for_op=kwargs,
+                     accepted_kwargs=kwargs,
                      L.cache
                     )
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -17,9 +17,9 @@ function (::AbstractSciMLOperator) end
 
 # Utilities for update functions
 DEFAULT_UPDATE_FUNC(A,u,p,t) = A
-function preprocess_update_func(update_func, accepted_kwarg_fields)
+function preprocess_update_func(update_func, accepted_kwargs)
     update_func = (update_func === nothing) ? DEFAULT_UPDATE_FUNC : update_func
-    return FilterKwargs(update_func, accepted_kwarg_fields)
+    return FilterKwargs(update_func, accepted_kwargs)
 end
 function update_func_isconstant(update_func)
     if update_func isa FilterKwargs

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -15,13 +15,20 @@ out-of-place form B = update_coefficients(A,u,p,t).
 """
 function (::AbstractSciMLOperator) end
 
+###
 # Utilities for update functions
+###
+
 DEFAULT_UPDATE_FUNC(A,u,p,t) = A
+
+struct NoKwargFilter end
+
 function preprocess_update_func(update_func, accepted_kwargs)
-    update_func = (update_func === nothing) ? DEFAULT_UPDATE_FUNC : update_func
+    _update_func = (update_func === nothing) ? DEFAULT_UPDATE_FUNC : update_func
+    _accepted_kwargs = (accepted_kwargs === nothing) ? () : accepted_kwargs 
     # accepted_kwargs can be passed as nothing to indicate that we should not filter 
     # (e.g. if the function already accepts all kwargs...). 
-    return (accepted_kwargs === nothing) ? update_func : FilterKwargs(update_func, accepted_kwargs)
+    return (_accepted_kwargs isa NoKwargFilter) ? _update_func : FilterKwargs(_update_func, _accepted_kwargs)
 end
 function update_func_isconstant(update_func)
     if update_func isa FilterKwargs

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -19,7 +19,9 @@ function (::AbstractSciMLOperator) end
 DEFAULT_UPDATE_FUNC(A,u,p,t) = A
 function preprocess_update_func(update_func, accepted_kwargs)
     update_func = (update_func === nothing) ? DEFAULT_UPDATE_FUNC : update_func
-    return FilterKwargs(update_func, accepted_kwargs)
+    # accepted_kwargs can be passed as nothing to indicate that we should not filter 
+    # (e.g. if the function already accepts all kwargs...). 
+    return (accepted_kwargs === nothing) ? update_func : FilterKwargs(update_func, accepted_kwargs)
 end
 function update_func_isconstant(update_func)
     if update_func isa FilterKwargs

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -1,6 +1,6 @@
 #
 """
-    MatrixOperator(A; update_func=nothing, accepted_kwarg_fields=())
+    MatrixOperator(A; update_func=nothing, accepted_kwargs=())
 
 Represents a time-dependent linear operator given by an AbstractMatrix. The
 update function is called by `update_coefficients!` and is assumed to have
@@ -11,8 +11,8 @@ the following signature:
 struct MatrixOperator{T,AType<:AbstractMatrix{T},F} <: AbstractSciMLOperator{T}
     A::AType
     update_func::F
-    function MatrixOperator(A::AType; update_func=nothing, accepted_kwarg_fields=()) where {AType}
-        _update_func = preprocess_update_func(update_func, accepted_kwarg_fields)
+    function MatrixOperator(A::AType; update_func=nothing, accepted_kwargs=()) where {AType}
+        _update_func = preprocess_update_func(update_func, accepted_kwargs)
         new{eltype(A),AType,typeof(_update_func)}(A, _update_func)
     end
 end
@@ -90,7 +90,7 @@ LinearAlgebra.ldiv!(v::AbstractVecOrMat, L::MatrixOperator, u::AbstractVecOrMat)
 LinearAlgebra.ldiv!(L::MatrixOperator, u::AbstractVecOrMat) = ldiv!(L.A, u)
 
 """
-    DiagonalOperator(diag; update_func=nothing, accepted_kwarg_fields=())
+    DiagonalOperator(diag; update_func=nothing, accepted_kwargs=())
 
 Represents a time-dependent elementwise scaling (diagonal-scaling) operation.
 The update function is called by `update_coefficients!` and is assumed to have
@@ -107,8 +107,8 @@ an operator of size `(N, N)` where `N = size(diag, 1)` is the leading length of 
 `L` then is the elementwise-scaling operation on arrays of `length(u) = length(diag)`
 with leading length `size(u, 1) = N`.
 """
-function DiagonalOperator(diag::AbstractVector; update_func=nothing, accepted_kwarg_fields=())
-    _update_func = preprocess_update_func(update_func, accepted_kwarg_fields)
+function DiagonalOperator(diag::AbstractVector; update_func=nothing, accepted_kwargs=())
+    _update_func = preprocess_update_func(update_func, accepted_kwargs)
     diag_update_func = if update_func_isconstant(_update_func)
         _update_func
     else
@@ -205,7 +205,7 @@ LinearAlgebra.ldiv!(v::AbstractVecOrMat, L::InvertibleOperator, u::AbstractVecOr
 LinearAlgebra.ldiv!(L::InvertibleOperator, u::AbstractVecOrMat) = ldiv!(L.F, u)
 
 """
-    L = AffineOperator(A, B, b; update_func=nothing, accepted_kwarg_fields=())
+    L = AffineOperator(A, B, b; update_func=nothing, accepted_kwargs=())
     L(u) = A*u + B*b
 
 Represents a time-dependent affine operator. The update function is called
@@ -240,12 +240,12 @@ function AffineOperator(A::Union{AbstractMatrix,AbstractSciMLOperator},
                         B::Union{AbstractMatrix,AbstractSciMLOperator},
                         b::AbstractArray;
                         update_func=nothing,
-                        accepted_kwarg_fields=()
+                        accepted_kwargs=()
                        )
     @assert size(A, 1) == size(B, 1) "Dimension mismatch: A, B don't output vectors
     of same size"
 
-    _update_func = preprocess_update_func(update_func, accepted_kwarg_fields)
+    _update_func = preprocess_update_func(update_func, accepted_kwargs)
 
     A = A isa AbstractMatrix ? MatrixOperator(A) : A
     B = B isa AbstractMatrix ? MatrixOperator(B) : B
@@ -255,11 +255,11 @@ function AffineOperator(A::Union{AbstractMatrix,AbstractSciMLOperator},
 end
 
 """
-    L = AddVector(b; update_func=nothing, accepted_kwarg_fields=())
+    L = AddVector(b; update_func=nothing, accepted_kwargs=())
     L(u) = u + b
 """
-function AddVector(b::AbstractVecOrMat; update_func=nothing, accepted_kwarg_fields=())
-    _update_func = preprocess_update_func(update_func, accepted_kwarg_fields)
+function AddVector(b::AbstractVecOrMat; update_func=nothing, accepted_kwargs=())
+    _update_func = preprocess_update_func(update_func, accepted_kwargs)
 
     N  = size(b, 1)
     Id = IdentityOperator(N)
@@ -268,11 +268,11 @@ function AddVector(b::AbstractVecOrMat; update_func=nothing, accepted_kwarg_fiel
 end
 
 """
-    L = AddVector(B, b; update_func=nothing, accepted_kwarg_fields=())
+    L = AddVector(B, b; update_func=nothing, accepted_kwargs=())
     L(u) = u + B*b
 """
-function AddVector(B, b::AbstractVecOrMat; update_func=nothing, accepted_kwarg_fields=())
-    _update_func = preprocess_update_func(update_func, accepted_kwarg_fields)
+function AddVector(B, b::AbstractVecOrMat; update_func=nothing, accepted_kwargs=())
+    _update_func = preprocess_update_func(update_func, accepted_kwargs)
 
     N = size(B, 1)
     Id = IdentityOperator(N)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -155,10 +155,10 @@ function DiagonalOperator(diag::AbstractVector;
                          )
 
     diag_update_func = update_func_isconstant(update_func) ? update_func :
-        (A, u, p, t; kwargs...) -> (update_func(A.diag, u, p, t; kwargs...); A)
+        (A, u, p, t; kwargs...) -> update_func(A.diag, u, p, t; kwargs...) |> Diagonal
 
     diag_update_func! = update_func_isconstant(update_func!) ? update_func! :
-        (A, u, p, t; kwargs...) -> (update_func!(A.diag, u, p, t; kwargs...); A)
+        (A, u, p, t; kwargs...) -> update_func!(A.diag, u, p, t; kwargs...)
 
     MatrixOperator(Diagonal(diag);
                    update_func = diag_update_func,

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -42,7 +42,7 @@ for op in (
             MatrixOperator($op(L.A))
         else
             update_func = (A,u,p,t; kwargs...) -> $op(L.update_func($op(L.A),u,p,t; kwargs...))
-            MatrixOperator($op(L.A); update_func = update_func)
+            MatrixOperator($op(L.A); update_func = update_func, accepted_kwargs=nothing)
         end
     end
 end
@@ -79,7 +79,7 @@ Base.copyto!(L::MatrixOperator, rhs::Base.Broadcast.Broadcasted{<:StaticArraysCo
 Base.Broadcast.broadcastable(L::MatrixOperator) = L
 Base.ndims(::Type{<:MatrixOperator{T,AType}}) where{T,AType} = ndims(AType)
 ArrayInterface.issingular(L::MatrixOperator) = ArrayInterface.issingular(L.A)
-Base.copy(L::MatrixOperator) = MatrixOperator(copy(L.A);update_func=L.update_func)
+Base.copy(L::MatrixOperator) = MatrixOperator(copy(L.A);update_func=L.update_func, accepted_kwargs=nothing)
 
 # operator application
 Base.:*(L::MatrixOperator, u::AbstractVecOrMat) = L.A * u
@@ -114,7 +114,7 @@ function DiagonalOperator(diag::AbstractVector; update_func=nothing, accepted_kw
     else
         (A, u, p, t; kwargs...) -> (_update_func(A.diag, u, p, t; kwargs...); A)
     end
-    MatrixOperator(Diagonal(diag); update_func=diag_update_func)
+    MatrixOperator(Diagonal(diag); update_func=diag_update_func, accepted_kwargs=nothing)
 end
 LinearAlgebra.Diagonal(L::MatrixOperator) = MatrixOperator(Diagonal(L.A))
 
@@ -264,7 +264,7 @@ function AddVector(b::AbstractVecOrMat; update_func=nothing, accepted_kwargs=())
     N  = size(b, 1)
     Id = IdentityOperator(N)
 
-    AffineOperator(Id, Id, b; update_func=_update_func)
+    AffineOperator(Id, Id, b; update_func=_update_func, accepted_kwargs=nothing)
 end
 
 """
@@ -277,7 +277,7 @@ function AddVector(B, b::AbstractVecOrMat; update_func=nothing, accepted_kwargs=
     N = size(B, 1)
     Id = IdentityOperator(N)
 
-    AffineOperator(Id, B, b; update_func=_update_func)
+    AffineOperator(Id, B, b; update_func=_update_func, accepted_kwargs=nothing)
 end
 
 getops(L::AffineOperator) = (L.A, L.B, L.b)

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -90,7 +90,7 @@ end
 Base.:+(α::AbstractSciMLScalarOperator) = α
 
 """
-    ScalarOperator(val; update_func=nothing, accepted_kwargs=())
+    ScalarOperator(val; [update_func, accepted_kwargs])
 
     (α::ScalarOperator)(a::Number) = α * a
 
@@ -98,7 +98,7 @@ Represents a time-dependent scalar/scaling operator. The update function
 is called by `update_coefficients!` and is assumed to have the following
 signature:
 
-    update_func(oldval,u,p,t; <accepted kwarg fields>) -> newval
+    update_func(oldval,u,p,t; <accepted kwargs>) -> newval
 """
 mutable struct ScalarOperator{T<:Number,F} <: AbstractSciMLScalarOperator{T}
     val::T
@@ -121,7 +121,7 @@ ScalarOperator(λ::UniformScaling) = ScalarOperator(λ.λ)
 function Base.conj(α::ScalarOperator) # TODO - test
     val = conj(α.val)
     update_func = (oldval,u,p,t; kwargs...) -> α.update_func(oldval |> conj,u,p,t; kwargs...) |> conj
-    ScalarOperator(val; update_func=update_func, accepted_kwargs=nothing)
+    ScalarOperator(val; update_func=update_func, accepted_kwargs=NoKwargFilter())
 end
 
 Base.one(::AbstractSciMLScalarOperator{T}) where{T} = ScalarOperator(one(T))

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -121,7 +121,7 @@ ScalarOperator(λ::UniformScaling) = ScalarOperator(λ.λ)
 function Base.conj(α::ScalarOperator) # TODO - test
     val = conj(α.val)
     update_func = (oldval,u,p,t; kwargs...) -> α.update_func(oldval |> conj,u,p,t; kwargs...) |> conj
-    ScalarOperator(val; update_func=update_func)
+    ScalarOperator(val; update_func=update_func, accepted_kwargs=nothing)
 end
 
 Base.one(::AbstractSciMLScalarOperator{T}) where{T} = ScalarOperator(one(T))

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -90,7 +90,7 @@ end
 Base.:+(α::AbstractSciMLScalarOperator) = α
 
 """
-    ScalarOperator(val; update_func=nothing, accepted_kwarg_fields=())
+    ScalarOperator(val; update_func=nothing, accepted_kwargs=())
 
     (α::ScalarOperator)(a::Number) = α * a
 
@@ -104,8 +104,8 @@ mutable struct ScalarOperator{T<:Number,F} <: AbstractSciMLScalarOperator{T}
     val::T
     update_func::F
 
-    function ScalarOperator(val::T; update_func=nothing, accepted_kwarg_fields=()) where {T}
-        _update_func = preprocess_update_func(update_func, accepted_kwarg_fields)
+    function ScalarOperator(val::T; update_func=nothing, accepted_kwargs=()) where {T}
+        _update_func = preprocess_update_func(update_func, accepted_kwargs)
         new{T,typeof(_update_func)}(val, _update_func)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,9 @@ struct FilterKwargs{F,K}
     accepted_kwargs::K
 end
 function (f_filter::FilterKwargs)(args...; kwargs...)
-    filtered_kwargs = (kwarg => kwargs[kwarg] for kwarg in f_filter.accepted_kwargs)
+    # Filter keyword arguments to those accepted by function.
+    # Avoid throwing errors here if a keyword argument is not provided: defer this to the function call for a more readable error.
+    filtered_kwargs = (kwarg => kwargs[kwarg] for kwarg in f_filter.accepted_kwargs if haskey(kwargs, kwarg))
     f_filter.f(args...; filtered_kwargs...)
 end
 #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,13 +18,16 @@ struct FilterKwargs{F,K}
     f::F
     accepted_kwargs::K
 end
-function (f_filter::FilterKwargs)(args...; kwargs...)
-    # Filter keyword arguments to those accepted by function.
-    # Avoid throwing errors here if a keyword argument is not provided: defer this to the function call for a more readable error.
-    filtered_kwargs = (kwarg => kwargs[kwarg] for kwarg in f_filter.accepted_kwargs if haskey(kwargs, kwarg))
-    f_filter.f(args...; filtered_kwargs...)
+
+# Filter keyword arguments to those accepted by function.
+# Avoid throwing errors here if a keyword argument is not provided: defer
+# this to the function call for a more readable error.
+function get_filtered_kwargs(kwargs::Base.Pairs, accepted_kwargs::NTuple{N,Symbol}) where{N}
+    (kw => kwargs[kw] for kw in accepted_kwargs if haskey(kwargs, kw))
 end
-# automatically convert NamedTuple's, etc. to a normalized kwargs representation (i.e. Base.Pairs) 
-normalize_kwargs(; kwargs...) = kwargs
-normalize_kwargs(kwargs) = normalize_kwargs(; kwargs...)
+
+function (f::FilterKwargs)(args...; kwargs...)
+    filtered_kwargs = get_filtered_kwargs(kwargs, f.accepted_kwargs)
+    f.f(args...; filtered_kwargs...)
+end
 #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,10 +16,10 @@ dims(::AbstractSciMLOperator) = 2
 # Keyword argument filtering
 struct FilterKwargs{F,K}
     f::F
-    accepted_kwarg_fields::K
+    accepted_kwargs::K
 end
 function (f_filter::FilterKwargs)(args...; kwargs...)
-    filtered_kwargs = (kwarg => kwargs[kwarg] for kwarg in f_filter.accepted_kwarg_fields)
+    filtered_kwargs = (kwarg => kwargs[kwarg] for kwarg in f_filter.accepted_kwargs)
     f_filter.f(args...; filtered_kwargs...)
 end
 #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,4 +24,7 @@ function (f_filter::FilterKwargs)(args...; kwargs...)
     filtered_kwargs = (kwarg => kwargs[kwarg] for kwarg in f_filter.accepted_kwargs if haskey(kwargs, kwarg))
     f_filter.f(args...; filtered_kwargs...)
 end
+# automatically convert NamedTuple's, etc. to a normalized kwargs representation (i.e. Base.Pairs) 
+normalize_kwargs(; kwargs...) = kwargs
+normalize_kwargs(kwargs) = normalize_kwargs(; kwargs...)
 #

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,7 +22,7 @@ end
 # Filter keyword arguments to those accepted by function.
 # Avoid throwing errors here if a keyword argument is not provided: defer
 # this to the function call for a more readable error.
-function get_filtered_kwargs(kwargs::Base.Pairs, accepted_kwargs::NTuple{N,Symbol}) where{N}
+function get_filtered_kwargs(kwargs::AbstractDict, accepted_kwargs::NTuple{N,Symbol}) where{N}
     (kw => kwargs[kw] for kw in accepted_kwargs if haskey(kwargs, kw))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,4 +12,14 @@ end
 dims(A) = length(size(A))
 dims(::AbstractArray{<:Any,N}) where{N} = N
 dims(::AbstractSciMLOperator) = 2
+
+# Keyword argument filtering
+struct FilterKwargs{F,K}
+    f::F
+    accepted_kwarg_fields::K
+end
+function (f_filter::FilterKwargs)(args...; kwargs...)
+    filtered_kwargs = (kwarg => kwargs[kwarg] for kwarg in f_filter.accepted_kwarg_fields)
+    f_filter.f(args...; filtered_kwargs...)
+end
 #

--- a/test/func.jl
+++ b/test/func.jl
@@ -94,18 +94,20 @@ end
     u = rand(N,K)
     p = rand(N)
     t = rand()
+    scale = rand()
 
-    f(du,u,p,t) = mul!(du, Diagonal(p*t), u)
+    # Accept a kwarg "scale" in operator action
+    f(du,u,p,t; scale) = begin @show scale; mul!(du, Diagonal(p*t*scale), u) end
 
-    L = FunctionOperator(f, u, u; p=zero(p), t=zero(t))
+    L = FunctionOperator(f, u, u; p=zero(p), t=zero(t), kwargs_for_op=(;scale=zero(scale)))
 
-    ans = @. u * p * t
-    @test L(u,p,t) ≈ ans
-    v=copy(u); @test L(v,u,p,t) ≈ ans
+    ans = @. u * p * t * scale 
+    @test L(u,p,t; scale) ≈ ans
+    v=copy(u); @test L(v,u,p,t; scale) ≈ ans
 
     # test that output isn't accidentally mutated by passing an internal cache.
 
-    A = Diagonal(p * t)
+    A = Diagonal(p * t * scale)
     u1 = rand(N, K)
     u2 = rand(N, K)
 

--- a/test/func.jl
+++ b/test/func.jl
@@ -107,10 +107,11 @@ end
     scale = rand()
 
     # Accept a kwarg "scale" in operator action
-    f(du,u,p,t; scale) = mul!(du, Diagonal(p*t*scale), u)
-    f(u, p, t; scale) = Diagonal(p * t * scale) * u
+    f(du,u,p,t; scale = 1.0) = mul!(du, Diagonal(p*t*scale), u)
+    f(u, p, t; scale = 1.0) = Diagonal(p * t * scale) * u
 
-    L = FunctionOperator(f, u, u; p=zero(p), t=zero(t), accepted_kwargs=(;scale=zero(scale)))
+    L = FunctionOperator(f, u, u; p=zero(p), t=zero(t),
+                         accepted_kwargs = (:scale,))
 
     ans = @. u * p * t * scale 
     @test L(u,p,t; scale) ≈ ans

--- a/test/func.jl
+++ b/test/func.jl
@@ -99,7 +99,7 @@ end
     # Accept a kwarg "scale" in operator action
     f(du,u,p,t; scale) = begin @show scale; mul!(du, Diagonal(p*t*scale), u) end
 
-    L = FunctionOperator(f, u, u; p=zero(p), t=zero(t), kwargs_for_op=(;scale=zero(scale)))
+    L = FunctionOperator(f, u, u; p=zero(p), t=zero(t), accepted_kwargs=(;scale=zero(scale)))
 
     ans = @. u * p * t * scale 
     @test L(u,p,t; scale) ≈ ans

--- a/test/func.jl
+++ b/test/func.jl
@@ -97,7 +97,7 @@ end
     scale = rand()
 
     # Accept a kwarg "scale" in operator action
-    f(du,u,p,t; scale) = begin @show scale; mul!(du, Diagonal(p*t*scale), u) end
+    f(du,u,p,t; scale) = mul!(du, Diagonal(p*t*scale), u)
 
     L = FunctionOperator(f, u, u; p=zero(p), t=zero(t), accepted_kwargs=(;scale=zero(scale)))
 

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -151,7 +151,7 @@ end
     # Test scalar operator which expects keyword argument to update,
     # modeled in the style of a DiffEq W-operator.
     γ = ScalarOperator(0.0; update_func = (args...; dtgamma) -> dtgamma,
-                       accepted_kwargs=(:dtgamma,))
+                       accepted_kwargs = (:dtgamma,))
 
     dtgamma = rand()
     @test γ(u,p,t; dtgamma) ≈ dtgamma * u

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -84,7 +84,7 @@ end
     @test convert(Number, num) ≈ val
 
     # Test scalar operator which expects keyword argument to update, modeled in the style of a DiffEq W-operator.
-    γ = ScalarOperator(0.0; update_func=(args...; dtgamma) -> dtgamma, accepted_kwarg_fields=(:dtgamma,))
+    γ = ScalarOperator(0.0; update_func=(args...; dtgamma) -> dtgamma, accepted_kwargs=(:dtgamma,))
 
     dtgamma = rand()
     @test γ(u,p,t; dtgamma) ≈ dtgamma * u

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -82,5 +82,16 @@ end
     @test num(v,u,p,t) ≈ val * u
 
     @test convert(Number, num) ≈ val
+
+    # Test scalar operator which expects keyword argument to update, modeled in the style of a DiffEq W-operator.
+    γ = ScalarOperator(0.0; update_func=(args...; dtgamma) -> dtgamma, accepted_kwarg_fields=(:dtgamma,))
+
+    dtgamma = rand()
+    @test γ(u,p,t; dtgamma) ≈ dtgamma * u
+    @test γ(v,u,p,t; dtgamma) ≈ dtgamma * u
+ 
+    γ_added = γ + α
+    @test γ_added(u,p,t; dtgamma) ≈ (dtgamma + p) * u
+    @test γ_added(v,u,p,t; dtgamma) ≈ (dtgamma + p) * u
 end
 #

--- a/test/total.jl
+++ b/test/total.jl
@@ -94,9 +94,9 @@ end
     T2 = ⊗(C, D)
 
     # Introduce update function for D1
-    D1  = DiagonalOperator(p * ones(N2); update_func=(A, u, p, t) -> (A .= p))
+    D1  = DiagonalOperator(zeros(N2); update_func=(d, u, p, t) -> (d .= p))
     # Introduce update funcion for D2 dependent on kwarg "diag" 
-    D2  = DiagonalOperator(p*t * diag; update_func=(A, u, p, t; diag) -> (A .= p*t*diag),
+    D2  = DiagonalOperator(zeros(N2); update_func=(d, u, p, t; diag) -> (d .= p*t*diag),
                            accepted_kwargs=(:diag,))
 
     TT = [T1, T2]

--- a/test/total.jl
+++ b/test/total.jl
@@ -86,7 +86,7 @@ end
     C = rand(N,N)
     # Introduce update function for D dependent on kwarg "matrix"
     D = MatrixOperator(zeros(N,N); update_func=(A, u, p, t; matrix) -> (A .= p*t*matrix), 
-                       accepted_kwargs=(:matrix,))
+                       accepted_kwargs = (:matrix,))
 
     u = rand(N2,K)
     p = rand()
@@ -99,11 +99,9 @@ end
     T1 = ⊗(A, B)
     T2 = ⊗(C, D)
 
-    # Introduce update function for D1
-    D1  = DiagonalOperator(zeros(N2); update_func=(d, u, p, t) -> (d .= p))
-    # Introduce update funcion for D2 dependent on kwarg "diag" 
-    D2  = DiagonalOperator(zeros(N2); update_func=(d, u, p, t; diag) -> (d .= p*t*diag),
-                           accepted_kwargs=(:diag,))
+    D1  = DiagonalOperator(zeros(N2); update_func = (d, u, p, t) -> p)
+    D2  = DiagonalOperator(zeros(N2); update_func = (d, u, p, t; diag) -> p*t*diag,
+                           accepted_kwargs = (:diag,))
 
     TT = [T1, T2]
     DD = Diagonal([D1, D2])

--- a/test/total.jl
+++ b/test/total.jl
@@ -82,10 +82,10 @@ end
 
     A = rand(N,N)
     # Introduce update function for B
-    B = MatrixOperator(zeros(N,N); update_func=(A, u, p, t) -> (A .= p))
+    B = MatrixOperator(zeros(N,N); update_func! = (A, u, p, t) -> (A .= p))
     C = rand(N,N)
     # Introduce update function for D dependent on kwarg "matrix"
-    D = MatrixOperator(zeros(N,N); update_func=(A, u, p, t; matrix) -> (A .= p*t*matrix), 
+    D = MatrixOperator(zeros(N,N); update_func! = (A, u, p, t; matrix) -> (A .= p*t*matrix), 
                        accepted_kwargs = (:matrix,))
 
     u = rand(N2,K)
@@ -99,8 +99,8 @@ end
     T1 = ⊗(A, B)
     T2 = ⊗(C, D)
 
-    D1  = DiagonalOperator(zeros(N2); update_func = (d, u, p, t) -> p)
-    D2  = DiagonalOperator(zeros(N2); update_func = (d, u, p, t; diag) -> p*t*diag,
+    D1  = DiagonalOperator(zeros(N2); update_func! = (d, u, p, t) -> d .= p)
+    D2  = DiagonalOperator(zeros(N2); update_func! = (d, u, p, t; diag) -> d .= p*t*diag,
                            accepted_kwargs = (:diag,))
 
     TT = [T1, T2]

--- a/test/total.jl
+++ b/test/total.jl
@@ -73,20 +73,31 @@ end
 
 @testset "Operator Algebra" begin
     N2 = N*N
+
     A = rand(N,N)
-    B = rand(N,N)
+    # Introduce update function for B
+    B = MatrixOperator(zeros(N,N); update_func=(A, u, p, t) -> (A .= p))
     C = rand(N,N)
-    D = rand(N,N)
+    # Introduce update function for D dependent on kwarg "matrix"
+    D = MatrixOperator(zeros(N,N); update_func=(A, u, p, t; matrix) -> (A .= p*t*matrix), 
+                       accepted_kwargs=(:matrix,))
 
     u = rand(N2,K)
+    p = rand()
+    t = rand()
+    matrix = rand(N, N)
+    diag = rand(N2)
     α = rand()
     β = rand()
 
     T1 = ⊗(A, B)
     T2 = ⊗(C, D)
 
-    D1  = DiagonalOperator(rand(N2))
-    D2  = DiagonalOperator(rand(N2))
+    # Introduce update function for D1
+    D1  = DiagonalOperator(p * ones(N2); update_func=(A, u, p, t) -> (A .= p))
+    # Introduce update funcion for D2 dependent on kwarg "diag" 
+    D2  = DiagonalOperator(p*t * diag; update_func=(A, u, p, t; diag) -> (A .= p*t*diag),
+                           accepted_kwargs=(:diag,))
 
     TT = [T1, T2]
     DD = Diagonal([D1, D2])
@@ -94,7 +105,19 @@ end
     op = TT' * DD * TT
     op = cache_operator(op, u)
 
+    # Update operator
+    @test_nowarn update_coefficients!(op, u, p, t; diag, matrix)
+    # Form dense operator manually 
+    dense_T1 = kron(A, p * ones(N, N))
+    dense_T2 = kron(C, (p*t) .* matrix)
+    dense_DD = Diagonal(vcat(p * ones(N2), p*t*diag))
+    dense_op = hcat(dense_T1', dense_T2') * dense_DD * vcat(dense_T1, dense_T2)
+    # Test correctness of op
+    @test op * u ≈ dense_op * u
+    @test convert(AbstractMatrix, op) ≈ dense_op 
+    # Test consistency with three-arg mul!
     v=rand(N2,K); @test mul!(v, op, u) ≈ op * u
+    # Test consistency with in-place five-arg mul!
     v=rand(N2,K); w=copy(v); @test mul!(v, op, u, α, β) ≈ α*(op * u) + β * w
 end
 #

--- a/test/total.jl
+++ b/test/total.jl
@@ -119,5 +119,8 @@ end
     v=rand(N2,K); @test mul!(v, op, u) ≈ op * u
     # Test consistency with in-place five-arg mul!
     v=rand(N2,K); w=copy(v); @test mul!(v, op, u, α, β) ≈ α*(op * u) + β * w
+    # Test consistency with operator application form
+    @test op(u, p, t; diag, matrix) ≈ op * u 
+    v=rand(N2,K); @test op(v, u, p, t; diag, matrix) ≈ op * u 
 end
 #


### PR DESCRIPTION
Resolves #125. For example usage, see the added test for a scalar operator. ~I left function operator mostly alone because I don't understand some aspects of it, and from some of the other issues it seems it still might be in flux. More comprehensive tests can be added in a follow up PR, but note that this change is totally backwards compatible.~ (Addressed)

For developers of this library, this is what you should know about the new design:

- Operator constructors called by the user should accept `update_func` and `accepted_kwargs` arguments, and preprocess them using the `preprocess_update_func` utility before making the struct, as done here.
- For internal calls to constructors where the `update_func` has already been processed, `accepted_kwargs` should be set to `NoKwargFilter()`, which indicates that no kwarg filtering should be done.