### PR TITLE
Require ndims is 2 for square

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -186,7 +186,7 @@ has_adjoint(::Union{
                    }
            ) = true
 
-issquare(L) = isequal(size(L)...)
+issquare(L) = ndims(L) == 2 && isequal(size(L)...)
 issquare(::Union{
                  # LinearAlgebra
                  UniformScaling,


### PR DESCRIPTION
Potential fix for https://github.com/SciML/DiffEqGPU.jl/pull/229