### PR TITLE
Remove unnecessary type information in identity and null operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
-version = "0.1.22"
+version = "0.2.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -1,25 +1,27 @@
 """
 $(TYPEDEF)
 """
-struct IdentityOperator{N} <: AbstractSciMLOperator{Bool} end
+struct IdentityOperator <: AbstractSciMLOperator{Bool}
+    len::Int
+end
 
 # constructors
-IdentityOperator(u::AbstractArray) = IdentityOperator{size(u,1)}()
+IdentityOperator(u::AbstractArray) = IdentityOperator(size(u,1))
 
 function Base.one(L::AbstractSciMLOperator)
     @assert issquare(L)
     N = size(L, 1)
-    IdentityOperator{N}()
+    IdentityOperator(N)
 end
 
-Base.convert(::Type{AbstractMatrix}, ::IdentityOperator{N}) where{N} = Diagonal(ones(Bool, N))
+Base.convert(::Type{AbstractMatrix}, ii::IdentityOperator) = Diagonal(ones(Bool, ii.len))
 
 # traits
-Base.size(::IdentityOperator{N}) where{N} = (N, N)
+Base.size(ii::IdentityOperator) = (ii.len, ii.len)
 Base.adjoint(A::IdentityOperator) = A
 Base.transpose(A::IdentityOperator) = A
 Base.conj(A::IdentityOperator) = A
-LinearAlgebra.opnorm(::IdentityOperator{N}, p::Real=2) where{N} = true
+LinearAlgebra.opnorm(::IdentityOperator, p::Real=2) = true
 for pred in (
              :issymmetric, :ishermitian, :isposdef,
             )
@@ -38,29 +40,29 @@ has_ldiv!(::IdentityOperator) = true
 for op in (
            :*, :\,
           )
-    @eval function Base.$op(::IdentityOperator{N}, u::AbstractVecOrMat) where{N}
-        @assert size(u, 1) == N
+    @eval function Base.$op(ii::IdentityOperator, u::AbstractVecOrMat)
+        @assert size(u, 1) == ii.len
         copy(u)
     end
 end
 
-function LinearAlgebra.mul!(v::AbstractVecOrMat, ::IdentityOperator{N}, u::AbstractVecOrMat) where{N}
-    @assert size(u, 1) == N
+function LinearAlgebra.mul!(v::AbstractVecOrMat, ii::IdentityOperator, u::AbstractVecOrMat)
+    @assert size(u, 1) == ii.len
     copy!(v, u)
 end
 
-function LinearAlgebra.mul!(v::AbstractVecOrMat, ::IdentityOperator{N}, u::AbstractVecOrMat, α, β) where{N}
-    @assert size(u, 1) == N
+function LinearAlgebra.mul!(v::AbstractVecOrMat, ii::IdentityOperator, u::AbstractVecOrMat, α, β)
+    @assert size(u, 1) == ii.len
     mul!(v, I, u, α, β)
 end
 
-function LinearAlgebra.ldiv!(v::AbstractVecOrMat, ::IdentityOperator{N}, u::AbstractVecOrMat) where{N}
-    @assert size(u, 1) == N
+function LinearAlgebra.ldiv!(v::AbstractVecOrMat, ii::IdentityOperator, u::AbstractVecOrMat)
+    @assert size(u, 1) == ii.len
     copy!(v, u)
 end
 
-function LinearAlgebra.ldiv!(::IdentityOperator{N}, u::AbstractVecOrMat) where{N}
-    @assert size(u, 1) == N
+function LinearAlgebra.ldiv!(ii::IdentityOperator, u::AbstractVecOrMat)
+    @assert size(u, 1) == ii.len
     u
 end
 
@@ -68,49 +70,51 @@ end
 for op in (
            :*, :∘,
           )
-    @eval function Base.$op(::IdentityOperator{N}, A::AbstractSciMLOperator) where{N}
-        @assert size(A, 1) == N
+    @eval function Base.$op(ii::IdentityOperator, A::AbstractSciMLOperator)
+        @assert size(A, 1) == ii.len
         A
     end
 
-    @eval function Base.$op(A::AbstractSciMLOperator, ::IdentityOperator{N}) where{N}
-        @assert size(A, 2) == N
+    @eval function Base.$op(A::AbstractSciMLOperator, ii::IdentityOperator)
+        @assert size(A, 2) == ii.len
         A
     end
 end
 
-function Base.:\(::IdentityOperator{N}, A::AbstractSciMLOperator) where{N}
-    @assert size(A, 1) == N
+function Base.:\(::IdentityOperator, A::AbstractSciMLOperator)
+    @assert size(A, 1) == ii.len
     A
 end
 
-function Base.:/(A::AbstractSciMLOperator, ::IdentityOperator{N}) where{N}
-    @assert size(A, 2) == N
+function Base.:/(A::AbstractSciMLOperator, ::IdentityOperator)
+    @assert size(A, 2) == ii.len
     A
 end
 
 """
 $(TYPEDEF)
 """
-struct NullOperator{N} <: AbstractSciMLOperator{Bool} end
+struct NullOperator <: AbstractSciMLOperator{Bool}
+    len::Int
+end
 
 # constructors
-NullOperator(u::AbstractArray) = NullOperator{size(u,1)}()
+NullOperator(u::AbstractArray) = NullOperator(size(u,1))
 
 function Base.zero(L::AbstractSciMLOperator)
     @assert issquare(L)
     N = size(L, 1)
-    NullOperator{N}()
+    NullOperator(N)
 end
 
-Base.convert(::Type{AbstractMatrix}, ::NullOperator{N}) where{N} = Diagonal(zeros(Bool, N))
+Base.convert(::Type{AbstractMatrix}, nn::NullOperator) = Diagonal(zeros(Bool, nn.len))
 
 # traits
-Base.size(::NullOperator{N}) where{N} = (N, N)
+Base.size(nn::NullOperator) = (nn.len, nn.len)
 Base.adjoint(A::NullOperator) = A
 Base.transpose(A::NullOperator) = A
 Base.conj(A::NullOperator) = A
-LinearAlgebra.opnorm(::NullOperator{N}, p::Real=2) where{N} = false
+LinearAlgebra.opnorm(::NullOperator, p::Real=2) = false
 for pred in (
              :issymmetric, :ishermitian,
             )
@@ -126,15 +130,15 @@ has_adjoint(::NullOperator) = true
 has_mul!(::NullOperator) = true
 
 # opeator application
-Base.:*(::NullOperator{N}, u::AbstractVecOrMat) where{N} = (@assert size(u, 1) == N; zero(u))
+Base.:*(nn::NullOperator, u::AbstractVecOrMat) = (@assert size(u, 1) == nn.len; zero(u))
 
-function LinearAlgebra.mul!(v::AbstractVecOrMat, ::NullOperator{N}, u::AbstractVecOrMat) where{N}
-    @assert size(u, 1) == size(v, 1) == N
+function LinearAlgebra.mul!(v::AbstractVecOrMat, nn::NullOperator, u::AbstractVecOrMat)
+    @assert size(u, 1) == size(v, 1) == nn.len
     lmul!(false, v)
 end
 
-function LinearAlgebra.mul!(v::AbstractVecOrMat, ::NullOperator{N}, u::AbstractVecOrMat, α, β) where{N}
-    @assert size(u, 1) == size(v, 1) == N
+function LinearAlgebra.mul!(v::AbstractVecOrMat, nn::NullOperator, u::AbstractVecOrMat, α, β)
+    @assert size(u, 1) == size(v, 1) == nn.len
     lmul!(β, v)
 end
 
@@ -142,14 +146,14 @@ end
 for op in (
            :*, :∘,
           )
-    @eval function Base.$op(::NullOperator{N}, A::AbstractSciMLOperator) where{N}
-        @assert size(A, 1) == N
-        NullOperator{N}()
+    @eval function Base.$op(nn::NullOperator, A::AbstractSciMLOperator)
+        @assert size(A, 1) == nn.len
+        NullOperator(nn.len)
     end
 
-    @eval function Base.$op(A::AbstractSciMLOperator, ::NullOperator{N}) where{N}
-        @assert size(A, 2) == N
-        NullOperator{N}()
+    @eval function Base.$op(A::AbstractSciMLOperator, nn::NullOperator)
+        @assert size(A, 2) == nn.len
+        NullOperator(nn.len)
     end
 end
 
@@ -157,13 +161,13 @@ end
 for op in (
            :+, :-,
           )
-    @eval function Base.$op(::NullOperator{N}, A::AbstractSciMLOperator) where{N}
-        @assert size(A) == (N, N)
+    @eval function Base.$op(nn::NullOperator, A::AbstractSciMLOperator)
+        @assert size(A) == (nn.len, nn.len)
         A
     end
 
-    @eval function Base.$op(A::AbstractSciMLOperator, ::NullOperator{N}) where{N}
-        @assert size(A) == (N, N)
+    @eval function Base.$op(A::AbstractSciMLOperator, nn::NullOperator)
+        @assert size(A) == (nn.len, nn.len)
         A
     end
 end
@@ -198,7 +202,7 @@ for T in SCALINGNUMBERTYPES
         λ = ScalarOperator(λ) * L.λ
         ScaledOperator(λ, L.L)
     end
-    
+
     for LT in SCALINGCOMBINETYPES
         @eval Base.:*(λ::$T, L::$LT) = ScaledOperator(λ, L)
         @eval Base.:*(L::$LT, λ::$T) = ScaledOperator(λ, L)
@@ -347,14 +351,14 @@ for op in (
             @eval function Base.$op(L::$LT, λ::$T)
                 @assert issquare(L)
                 N  = size(L, 1)
-                Id = IdentityOperator{N}()
+                Id = IdentityOperator(N)
                 AddedOperator(L, $op(λ)*Id)
             end
 
             @eval function Base.$op(λ::$T, L::$LT)
                 @assert issquare(L)
                 N  = size(L, 1)
-                Id = IdentityOperator{N}()
+                Id = IdentityOperator(N)
                 AddedOperator(λ*Id, $op(L))
             end
         end
@@ -459,24 +463,24 @@ for op in (
            :*, :∘,
           )
     # identity
-    @eval function Base.$op(::IdentityOperator{N}, A::ComposedOperator) where{N}
-        @assert size(A, 1) == N
+    @eval function Base.$op(ii::IdentityOperator, A::ComposedOperator)
+        @assert size(A, 1) == ii.len
         A
     end
 
-    @eval function Base.$op(A::ComposedOperator, ::IdentityOperator{N}) where{N}
-        @assert size(A, 2) == N
+    @eval function Base.$op(A::ComposedOperator, ii::IdentityOperator)
+        @assert size(A, 2) == ii.len
         A
     end
 
     # null operator
-    @eval function Base.$op(::NullOperator{N}, A::ComposedOperator) where{N}
-        @assert size(A, 1) == N
+    @eval function Base.$op(nn::NullOperator, A::ComposedOperator)
+        @assert size(A, 1) == nn.len
         zero(A)
     end
 
-    @eval function Base.$op(A::ComposedOperator, ::NullOperator{N}) where{N}
-        @assert size(A, 2) == N
+    @eval function Base.$op(A::ComposedOperator, nn::NullOperator)
+        @assert size(A, 2) == nn.len
         zero(A)
     end
 
@@ -561,7 +565,7 @@ function cache_self(L::ComposedOperator, u::AbstractVecOrMat)
             cache = (vec, cache...)
         end
     elseif has_ldiv(L)
-        m = size(L, 1) 
+        m = size(L, 1)
         k = size(u, 2)
         vec = u isa AbstractMatrix ? similar(u, (m, k)) : similar(u, (m,))
         cache = ()

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -254,7 +254,7 @@ end
 """
 function AddVector(b::AbstractVecOrMat; update_func = DEFAULT_UPDATE_FUNC)
     N  = size(b, 1)
-    Id = IdentityOperator{N}()
+    Id = IdentityOperator(N)
 
     AffineOperator(Id, Id, b; update_func=update_func)
 end
@@ -265,7 +265,7 @@ end
 """
 function AddVector(B, b::AbstractVecOrMat; update_func = DEFAULT_UPDATE_FUNC)
     N = size(B, 1)
-    Id = IdentityOperator{N}()
+    Id = IdentityOperator(N)
 
     AffineOperator(Id, B, b; update_func=update_func)
 end

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -9,7 +9,7 @@ SCALINGNUMBERTYPES = (
                       :UniformScaling,
                      )
 
-#= 
+#=
 The identity operator must be listed here
 so that rules for combination with scalar
 operators take precedence over rules for
@@ -18,7 +18,7 @@ the two are combined together.
 =#
 SCALINGCOMBINETYPES = (
     :AbstractSciMLOperator,
-    :(IdentityOperator{N} where {N})
+    :IdentityOperator
 )
 
 Base.size(α::AbstractSciMLScalarOperator) = ()
@@ -229,7 +229,7 @@ has_ldiv!(α::ComposedScalarOperator) = all(has_ldiv!, α.ops)
 Lazy inversion of Scalar Operators
 """
 #=
-Keeping with the style, we avoid use of the generic InvertedOperator and instead 
+Keeping with the style, we avoid use of the generic InvertedOperator and instead
 have a specialized type for this purpose that subtypes AbstractSciMLScalarOperator.
 =#
 struct InvertedScalarOperator{T,λType} <: AbstractSciMLScalarOperator{T}
@@ -246,10 +246,10 @@ for op in (
           )
     for T in SCALINGNUMBERTYPES[2:end]
         @eval Base.$op(α::AbstractSciMLScalarOperator, x::$T) = α * inv(ScalarOperator(x))
-        @eval Base.$op(x::$T, α::AbstractSciMLScalarOperator) = ScalarOperator(x) * inv(α) 
+        @eval Base.$op(x::$T, α::AbstractSciMLScalarOperator) = ScalarOperator(x) * inv(α)
     end
 
-    @eval Base.$op(α::AbstractSciMLScalarOperator, β::AbstractSciMLScalarOperator) = α * inv(β) 
+    @eval Base.$op(α::AbstractSciMLScalarOperator, β::AbstractSciMLScalarOperator) = α * inv(β)
 end
 
 for op in (

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -43,7 +43,7 @@ end
 TensorProductOperator(ops...) = reduce(TensorProductOperator, ops)
 TensorProductOperator(op::AbstractSciMLOperator) = op
 TensorProductOperator(op::AbstractMatrix) = MatrixOperator(op)
-TensorProductOperator(::IdentityOperator{No}, ::IdentityOperator{Ni}) where{No,Ni} = IdentityOperator{No*Ni}()
+TensorProductOperator(ii1::IdentityOperator, ii2::IdentityOperator) = IdentityOperator(ii1.len * ii2.len)
 
 # overload ⊗ (\otimes)
 ⊗(ops::Union{AbstractMatrix,AbstractSciMLOperator}...) = TensorProductOperator(ops...)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -25,17 +25,17 @@ K = 12
     u  = rand(N,K)
     α = rand()
     β = rand()
-    Id = IdentityOperator{N}()
+    Id = IdentityOperator(N)
 
     @test issquare(Id)
     @test islinear(Id)
-    @test IdentityOperator(u) isa IdentityOperator{N}
-    @test one(A) isa IdentityOperator{N}
+    @test IdentityOperator(u) isa IdentityOperator
+    @test one(A) isa IdentityOperator
     @test convert(AbstractMatrix, Id) == Matrix(I, N, N)
 
     @test iscached(Id)
     @test size(Id) == (N, N)
-    @test Id' isa IdentityOperator{N}
+    @test Id' isa IdentityOperator
     @test isconstant(Id)
 
     for op in (
@@ -63,18 +63,18 @@ end
     u = rand(N,K)
     α = rand()
     β = rand()
-    Z = NullOperator{N}()
+    Z = NullOperator(N)
 
     @test issquare(Z)
     @test islinear(Z)
-    @test NullOperator(u) isa NullOperator{N}
+    @test NullOperator(u) isa NullOperator
     @test isconstant(Z)
-    @test zero(A) isa NullOperator{N}
+    @test zero(A) isa NullOperator
     @test convert(AbstractMatrix, Z) == zeros(size(Z))
 
     @test iscached(Z)
     @test size(Z) == (N, N)
-    @test Z' isa NullOperator{N}
+    @test Z' isa NullOperator
 
     @test Z * u ≈ zero(u)
 
@@ -229,7 +229,7 @@ end
     # We can now test that caching does not rely on matmul
     op = inner_op * factorize(MatrixOperator(rand(N, N)))
     @test !iscached(op)
-    @test_nowarn op = cache_operator(op, rand(N)) 
+    @test_nowarn op = cache_operator(op, rand(N))
     @test iscached(op)
     u = rand(N)
     @test ldiv!(rand(N), op, u) ≈ op \ u

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -42,21 +42,21 @@ K = 12
     @test α * α isa SciMLOperators.ComposedScalarOperator
     (α * α) * u ≈ x * x * u
     @test inv(α) isa SciMLOperators.InvertedScalarOperator
-    inv(α) * u ≈ 1/x * u 
+    inv(α) * u ≈ 1/x * u
     @test α * inv(α) isa SciMLOperators.ComposedScalarOperator
-    α * inv(α) * u ≈ u 
+    α * inv(α) * u ≈ u
     @test α / α isa SciMLOperators.ComposedScalarOperator
-    α * α * u ≈ u 
+    α * α * u ≈ u
 
     # Test combination with other operators
-    for op in (MatrixOperator(rand(N, N)), SciMLOperators.IdentityOperator{N}())
+    for op in (MatrixOperator(rand(N, N)), SciMLOperators.IdentityOperator(N))
         @test α + op isa SciMLOperators.AddedOperator
         @test (α + op) * u ≈ x * u + op * u
         @test α * op isa SciMLOperators.ScaledOperator
         @test (α * op) * u ≈ x * (op * u)
         @test all(map(T -> (T isa SciMLOperators.ScaledOperator), (α / op, op / α, op \ α, α \ op)))
         @test (α / op) * u ≈ (op \ α) * u ≈ α * (op \ u)
-        @test (op / α) * u ≈ (α \ op) * u ≈ 1/α * op * u 
+        @test (op / α) * u ≈ (α \ op) * u ≈ 1/α * op * u
     end
 end
 

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -23,8 +23,8 @@ M = rand(N,N)
 
 for (op_type, A) in
     (
-     (IdentityOperator, IdentityOperator{N}()),
-     (NullOperator, NullOperator{N}()),
+     (IdentityOperator, IdentityOperator(N)),
+     (NullOperator, NullOperator(N)),
      (MatrixOperator, MatrixOperator(rand(N,N))),
      (AffineOperator, AffineOperator(rand(N,N), rand(N,N), rand(N,K))),
      (ScaledOperator, rand() * MatrixOperator(rand(N,N))),
@@ -48,7 +48,7 @@ for (op_type, A) in
     @assert A isa op_type
 
     loss_mul = function(p)
-    
+
         v = Diagonal(p) * u0
 
         w = A * v
@@ -83,4 +83,3 @@ for (op_type, A) in
         end
     end
 end
-


### PR DESCRIPTION
This both improves the performance of compile time and run times downstream by a lot. Such information should not be put into type space!

Bumps as a breaking change

Fixes https://github.com/SciML/SciMLOperators.jl/issues/154