### PR TITLE
Support `L(v, u, p, t, a, b)` corresponding to 5 arg `mul!`

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -34,7 +34,26 @@ end
 # caching interface
 ###
 
+getops(L) = ()
+
+need_self_cache(L) = false
+need_self_cache(::Union{
+                        # LinearAlgebra
+                        AbstractMatrix,
+                        UniformScaling,
+                        Factorization,
+
+                        # Base
+                        Number,
+
+                       }
+               ) = false
+
 function iscached(L::AbstractSciMLOperator)
+    #if !need_self_cache(L)
+    #    return false
+    #end
+
     has_cache = hasfield(typeof(L), :cache) # TODO - confirm this is static
     isset = has_cache ? L.cache !== nothing : true
 
@@ -42,6 +61,7 @@ function iscached(L::AbstractSciMLOperator)
 end
 
 iscached(L) = true
+
 iscached(::Union{
                  # LinearAlgebra
                  AbstractMatrix,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -36,23 +36,7 @@ end
 
 getops(L) = ()
 
-need_self_cache(L) = false
-need_self_cache(::Union{
-                        # LinearAlgebra
-                        AbstractMatrix,
-                        UniformScaling,
-                        Factorization,
-
-                        # Base
-                        Number,
-
-                       }
-               ) = false
-
 function iscached(L::AbstractSciMLOperator)
-    #if !need_self_cache(L)
-    #    return false
-    #end
 
     has_cache = hasfield(typeof(L), :cache) # TODO - confirm this is static
     isset = has_cache ? L.cache !== nothing : true
@@ -82,22 +66,22 @@ arguments:
     in :: AbstractVecOrMat input prototype to L
     out :: (optional) AbstractVecOrMat output prototype to L
 """
-cache_operator
+function cache_operator end
 
 cache_operator(L, u) = L
-cache_operatro(L, u, v) = L
-cache_self(L::AbstractSciMLOperator, uv::AbstractVecOrMat...) = L
-cache_internals(L::AbstractSciMLOperator, uv::AbstractVecOrMat...) = L
+cache_operator(L, u, v) = L
+cache_self(L::AbstractSciMLOperator, ::AbstractVecOrMat...) = L
+cache_internals(L::AbstractSciMLOperator, ::AbstractVecOrMat...) = L
 
-function cache_operator(L::AbstractSciMLOperator,
-                        u::AbstractVecOrMat,
-                        v::AbstractVecOrMat)
+function cache_operator(L::AbstractSciMLOperator, u::AbstractVecOrMat, v::AbstractVecOrMat)
+
     L = cache_self(L, u, v)
     L = cache_internals(L, u, v)
     L
 end
 
 function cache_operator(L::AbstractSciMLOperator, u::AbstractVecOrMat)
+
     L = cache_self(L, u)
     L = cache_internals(L, u)
     L

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -39,7 +39,7 @@ getops(L) = ()
 function iscached(L::AbstractSciMLOperator)
 
     has_cache = hasfield(typeof(L), :cache) # TODO - confirm this is static
-    isset = has_cache ? L.cache !== nothing : true
+    isset = has_cache ? !isnothing(L.cache) : true
 
     return isset & all(iscached, getops(L)) 
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -28,6 +28,7 @@ end
 
 (L::AbstractSciMLOperator)(u, p, t) = (update_coefficients!(L, u, p, t); L * u)
 (L::AbstractSciMLOperator)(du, u, p, t) = (update_coefficients!(L, u, p, t); mul!(du, L, u))
+(L::AbstractSciMLOperator)(du, u, p, t, α, β) = (update_coefficients!(L, u, p, t); mul!(du, L, u, α, β))
 
 ###
 # caching interface

--- a/test/func.jl
+++ b/test/func.jl
@@ -17,12 +17,15 @@ K = 12
 
     A = rand(N,N) |> Symmetric
     F = lu(A)
+    Ai = inv(A)
 
     f1(u, p, t)  = A * u
     f1i(u, p, t) = A \ u
 
     f2(du, u, p, t)  = mul!(du, A, u)
+    f2(du, u, p, t, α, β)  = mul!(du, A, u, α, β)
     f2i(du, u, p, t) = ldiv!(du, F, u)
+    f2i(du, u, p, t, α, β) = mul!(du, Ai, u, α, β)
 
     # out of place
     op1 = FunctionOperator(f1, u, A*u;
@@ -51,6 +54,7 @@ K = 12
                            ishermitian=true,
                            isposdef=true,
                           )
+
     @test issquare(op1)
     @test issquare(op2)
 
@@ -75,6 +79,12 @@ K = 12
 
     @test !iscached(op1)
     @test !iscached(op2)
+
+    @test !op1.traits.has_mul5
+    @test op2.traits.has_mul5
+
+    # 5-arg mul! (w/o cache)
+    v = rand(N,K); w=copy(v); @test α*(A*u)+ β*w ≈ mul!(v, op2, u, α, β)
 
     op1 = cache_operator(op1, u, A * u)
     op2 = cache_operator(op2, u, A * u)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -63,22 +63,27 @@ end
     p = rand(N)
     t = rand()
 
+    α = rand()
+    β = rand()
+
     L = MatrixOperator(zeros(N,N);
                        update_func = (A,u,p,t) -> (A .= p*p'; nothing)
                       )
 
     @test !isconstant(L)
 
-    A = p*p'
-    ans = A * u
-    @test L(u,p,t) ≈ ans
-    v=copy(u); @test L(v,u,p,t) ≈ ans
+    A = p * p'
+    @test L(u, p, t) ≈ A * u
+    v=copy(u); @test L(v, u, p, t) ≈ A * u
+    v=rand(N,K); w=copy(v); @test L(v, u, p, t, α, β) ≈ α*A*u + β*w
 end
 
 @testset "DiagonalOperator update test" begin
     u = rand(N,K)
     p = rand(N)
     t = rand()
+    α = rand()
+    β = rand()
 
     D = DiagonalOperator(zeros(N);
                          update_func = (diag,u,p,t) -> (diag .= p*t; nothing)
@@ -91,6 +96,7 @@ end
     ans = Diagonal(p*t) * u
     @test D(u,p,t) ≈ ans
     v=copy(u); @test D(v,u,p,t) ≈ ans
+    v=rand(N,K); w=copy(v); @test D(v, u, p, t, α, β) ≈ α*ans + β*w
 end
 
 @testset "Batched Diagonal Operator" begin
@@ -170,6 +176,8 @@ end
     u = rand(N,K)
     p = rand(N)
     t = rand()
+    α = rand()
+    β = rand()
 
     L = AffineOperator(A, B, b;
                        update_func = (b,u,p,t) -> (b .= Diagonal(p*t)*b; nothing)
@@ -183,6 +191,9 @@ end
     b = Diagonal(p*t)*b
     ans = A * u + B * b
     v=copy(u); @test L(v,u,p,t) ≈ ans
+    b = Diagonal(p*t)*b
+    ans = A * u + B * b
+    v=rand(N,K); w=copy(v); @test L(v, u, p, t, α, β) ≈ α*ans + β*w
 end
 
 @testset "TensorProductOperator" begin

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -61,10 +61,12 @@ K = 12
 end
 
 @testset "ScalarOperator update test" begin
-    u = ones(N,K)
-    v = zeros(N,K)
+    u = rand(N,K)
+    v = rand(N,K)
     p = rand()
     t = rand()
+    a = rand()
+    b = rand()
 
     α = ScalarOperator(0.0; update_func=(a,u,p,t) -> p)
     β = ScalarOperator(0.0; update_func=(a,u,p,t) -> t)
@@ -72,15 +74,31 @@ end
     @test !isconstant(α)
     @test !isconstant(β)
 
-    @test α(u,p,t)   ≈ p * u
-    @test α(v,u,p,t) ≈ p * u
+    @test convert(Number, α) ≈ 0.0
+    @test convert(Number, β) ≈ 0.0
+
+    update_coefficients!(α, u, p, t)
+    update_coefficients!(β, u, p, t)
+
+    @test convert(Number, α) ≈ p
+    @test convert(Number, β) ≈ t
+
+    @test α(u, p, t) ≈ p * u
+    v=rand(N,K); @test α(v, u, p, t) ≈ p * u
+    v=rand(N,K); w=copy(v); @test α(v, u, p, t, a, b) ≈ a*p*u + b*w
+
+    @test β(u, p, t) ≈ t * u
+    v=rand(N,K); @test β(v, u, p, t) ≈ t * u
+    v=rand(N,K); w=copy(v); @test β(v, u, p, t, a, b) ≈ a*t*u + b*w
 
     num = α + 2 / β * 3 - 4
     val = p + 2 / t * 3 - 4
 
-    @test num(u,p,t)   ≈ val * u
-    @test num(v,u,p,t) ≈ val * u
-
     @test convert(Number, num) ≈ val
+
+    @test num(u, p, t) ≈ val * u
+    v=rand(N,K); @test num(v, u, p, t) ≈ val * u
+    v=rand(N,K); w=copy(v); @test num(v, u, p, t, a, b) ≈ a*val*u + b*w
+
 end
 #


### PR DESCRIPTION
close https://github.com/SciML/SciMLOperators.jl/issues/151, https://github.com/SciML/SciMLOperators.jl/issues/48

- [x] update interface, tests
- [x] allow user to pass 5 arg mul! in FunctionOperator