### PR TITLE
fix typo that's causing warnings

### DIFF
--- a/src/func.jl
+++ b/src/func.jl
@@ -225,7 +225,7 @@ function iscached(L::FunctionOperator)
 end
 
 function cache_self(L::FunctionOperator, u::AbstractVecOrMat, v::AbstractVecOrMat)
-    L.traits.ifcache && @warn "you are allocating cache for a FunctionOperator for which ifcache = false."
+    !L.traits.ifcache && @warn "you are allocating cache for a FunctionOperator for which ifcache = false."
     @set! L.cache = zero.((u, v))
     L
 end


### PR DESCRIPTION
This is causing warnings in https://github.com/SciML/OrdinaryDiffEq.jl/pull/1917

merge and minor bump please? @xtalax 