### PR TITLE
fixed scalaroperator convert methods. 

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -226,6 +226,7 @@ issquare(::Union{
         ) = true
 issquare(A...) = @. (&)(issquare(A)...)
 
+Base.length(L::AbstractSciMLOperator) = prod(size(L))
 Base.ndims(L::AbstractSciMLOperator) = length(size(L))
 Base.isreal(L::AbstractSciMLOperator{T}) where{T} = T <: Real
 Base.Matrix(L::AbstractSciMLOperator) = Matrix(convert(AbstractMatrix, L))

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -21,6 +21,7 @@ SCALINGCOMBINETYPES = (
     :IdentityOperator
 )
 
+Base.length(::AbstractSciMLScalarOperator) = 1
 Base.size(α::AbstractSciMLScalarOperator) = ()
 Base.adjoint(α::AbstractSciMLScalarOperator) = conj(α)
 Base.transpose(α::AbstractSciMLScalarOperator) = α

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -110,7 +110,7 @@ function ScalarOperator(val::T; update_func=DEFAULT_UPDATE_FUNC) where{T}
 end
 
 # constructors
-Base.convert(::Type{Number}, α::ScalarOperator) = α.val
+Base.convert(T::Type{<:Number}, α::ScalarOperator) = convert(T, α.val)
 Base.convert(::Type{ScalarOperator}, α::Number) = ScalarOperator(α)
 
 ScalarOperator(α::AbstractSciMLScalarOperator) = α
@@ -173,8 +173,8 @@ for op in (
     end
 end
 
-function Base.convert(::Type{Number}, α::AddedScalarOperator{T}) where{T}
-    sum(op -> convert(Number, op), α.ops)
+function Base.convert(T::Type{<:Number}, α::AddedScalarOperator)
+    sum(convert.(T, α.ops))
 end
 
 Base.conj(L::AddedScalarOperator) = AddedScalarOperator(conj.(L.ops))
@@ -222,9 +222,9 @@ for op in (
     end
 end
 
-function Base.convert(::Type{Number}, α::ComposedScalarOperator{T}) where{T}
+function Base.convert(T::Type{<:Number}, α::ComposedScalarOperator)
     iszero(α) && return zero(T)
-    prod( op -> convert(Number, op), α.ops; init=one(T))
+    prod(convert.(T, α.ops))
 end
 
 Base.conj(L::ComposedScalarOperator) = ComposedScalarOperator(conj.(L.ops))
@@ -279,8 +279,8 @@ for op in (
     @eval Base.$op(α::AbstractSciMLScalarOperator, β::AbstractSciMLScalarOperator) = inv(α) * β
 end
 
-function Base.convert(::Type{Number}, α::InvertedScalarOperator{T}) where{T}
-    return inv(convert(Number, α.λ))
+function Base.convert(T::Type{<:Number}, α::InvertedScalarOperator)
+    inv(convert(Number, α.λ))
 end
 
 Base.conj(L::InvertedScalarOperator) = InvertedScalarOperator(conj(L.λ))

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -18,7 +18,7 @@ K = 12
     @test issquare(α)
     @test islinear(α)
 
-    @test convert(Number, α) isa Number
+    @test convert(Float32, α) isa Float32
     @test convert(ScalarOperator, a) isa ScalarOperator
 
     @test size(α) == ()
@@ -37,16 +37,35 @@ K = 12
     @test axpy!(aa,X,Y) ≈ a*X+Z
 
     # Test that ScalarOperator's remain AbstractSciMLScalarOperator's under common ops
-    @test α + α isa SciMLOperators.AddedScalarOperator
-    (α + α) * u ≈ x * u + x * u
-    @test α * α isa SciMLOperators.ComposedScalarOperator
-    (α * α) * u ≈ x * x * u
-    @test inv(α) isa SciMLOperators.InvertedScalarOperator
-    inv(α) * u ≈ 1/x * u
-    @test α * inv(α) isa SciMLOperators.ComposedScalarOperator
-    α * inv(α) * u ≈ u
-    @test α / α isa SciMLOperators.ComposedScalarOperator
-    α * α * u ≈ u
+    β = α + α
+    @test β isa SciMLOperators.AddedScalarOperator
+    @test β * u ≈ x * u + x * u
+    @inferred convert(Float32, β)
+    @test convert(Number, β) ≈ x + x
+
+    β = α * α
+    @test β isa SciMLOperators.ComposedScalarOperator
+    @test β * u ≈ x * x * u
+    @inferred convert(Float32, β)
+    @test convert(Number, β) ≈ x * x
+
+    β = inv(α)
+    @test β isa SciMLOperators.InvertedScalarOperator
+    @test β * u ≈ 1 / x * u
+    @inferred convert(Float32, β)
+    @test convert(Number, β) ≈ 1 / x
+
+    β = α * inv(α)
+    @test β isa SciMLOperators.ComposedScalarOperator
+    @test β * u ≈ u
+    @inferred convert(Float32, β)
+    @test convert(Number, β) ≈ true
+
+    β = α / α
+    @test β isa SciMLOperators.ComposedScalarOperator
+    @test β * u ≈ u
+    @inferred convert(Float32, β)
+    @test convert(Number, β) ≈ true
 
     # Test combination with other operators
     for op in (MatrixOperator(rand(N, N)), SciMLOperators.IdentityOperator(N))
@@ -73,6 +92,9 @@ end
 
     @test !isconstant(α)
     @test !isconstant(β)
+
+    @test convert(Float32, α) isa Float32
+    @test convert(Float32, β) isa Float32
 
     @test convert(Number, α) ≈ 0.0
     @test convert(Number, β) ≈ 0.0


### PR DESCRIPTION
they can also infer type now

fix errors in https://github.com/SciML/OrdinaryDiffEq.jl/pull/1917 (linear-nonlinear method test)