### PR TITLE
Fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -330,8 +330,9 @@ AddedOperator(L::AbstractSciMLOperator) = L
 # constructors
 Base.:+(A::AbstractSciMLOperator, B::AbstractMatrix) = A + MatrixOperator(B)
 Base.:+(A::AbstractMatrix, B::AbstractSciMLOperator) = MatrixOperator(A) + B
-Base.:+(ops::AbstractSciMLOperator...) = AddedOperator(ops...)
 
+Base.:+(ops::AbstractSciMLOperator...) = reduce(+, ops)
+Base.:+(A::AbstractSciMLOperator, B::AbstractSciMLOperator) = AddedOperator(A, B)
 Base.:+(A::AbstractSciMLOperator, B::AddedOperator) = AddedOperator(A, B.ops...)
 Base.:+(A::AddedOperator, B::AbstractSciMLOperator) = AddedOperator(A.ops..., B)
 Base.:+(A::AddedOperator, B::AddedOperator) = AddedOperator(A.ops..., B.ops...)

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -214,10 +214,11 @@ end
 for op in (
            :*, :∘,
           )
-    @eval Base.$op(ops::AbstractSciMLScalarOperator...) = ComposedScalarOperator(ops...)
-    @eval Base.$op(A::ComposedScalarOperator, B::ComposedScalarOperator) = ComposedScalarOperator(A.ops..., B.ops...)
-    @eval Base.$op(A::AbstractSciMLScalarOperator, B::ComposedScalarOperator) = ComposedScalarOperator(A, B.ops...)
+    @eval Base.$op(ops::AbstractSciMLScalarOperator...) = reduce($op, ops)
+    @eval Base.$op(A::AbstractSciMLScalarOperator, B::AbstractSciMLScalarOperator) = ComposedScalarOperator(A, B)
     @eval Base.$op(A::ComposedScalarOperator, B::AbstractSciMLScalarOperator) = ComposedScalarOperator(A.ops..., B)
+    @eval Base.$op(A::AbstractSciMLScalarOperator, B::ComposedScalarOperator) = ComposedScalarOperator(A, B.ops...)
+    @eval Base.$op(A::ComposedScalarOperator, B::ComposedScalarOperator) = ComposedScalarOperator(A.ops..., B.ops...)
 
     for T in SCALINGNUMBERTYPES[2:end]
         @eval Base.$op(α::AbstractSciMLScalarOperator, x::$T) = ComposedScalarOperator(α, ScalarOperator(x))

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -221,6 +221,14 @@ end
     v=rand(N,K); @test ldiv!(v, op, u) ≈ (A * B * C) \ u
     v=copy(u);   @test ldiv!(op, u)    ≈ (A * B * C) \ v
 
+    # ensure composedoperators don't nest
+    A = MatrixOperator(rand(N, N))
+    L = A * (A * A) * A
+    @test L isa ComposedOperator
+    for op in L.ops
+        @test !isa(op, ComposedOperator)
+    end
+
     # Test caching of composed operator when inner ops do not support Base.:*
     # ComposedOperator caching was modified in PR # 174
     inner_op = qr(MatrixOperator(rand(N, N)))

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -171,6 +171,15 @@ end
 
     v=rand(N,K); @test mul!(v, op, u) ≈ (A+B) * u
     v=rand(N,K); w=copy(v); @test mul!(v, op, u, α, β) ≈ α*(A+B)*u + β*w
+
+    # ensure AddedOperator doesn't nest
+    A = MatrixOperator(rand(N, N))
+    L = A + (A + A) + A
+    @test L isa AddedOperator
+    for op in L.ops
+        @test !isa(op, AddedOperator)
+    end
+
 end
 
 @testset "ComposedOperator" begin
@@ -221,7 +230,7 @@ end
     v=rand(N,K); @test ldiv!(v, op, u) ≈ (A * B * C) \ u
     v=copy(u);   @test ldiv!(op, u)    ≈ (A * B * C) \ v
 
-    # ensure composedoperators don't nest
+    # ensure composedoperators doesn't nest
     A = MatrixOperator(rand(N, N))
     L = A * (A * A) * A
     @test L isa ComposedOperator

--- a/test/total.jl
+++ b/test/total.jl
@@ -35,11 +35,17 @@ K = 12
     ik = im * DiagonalOperator(k)
     Dx = ftr \ ik * ftr
     Dx = cache_operator(Dx, x)
+    D2x = cache_operator(Dx * Dx, x)
 
-    u  = @. sin(5x)cos(7x);
-    du = @. 5cos(5x)cos(7x) - 7sin(5x)sin(7x);
+    u   = @. sin(5x)cos(7x);
+    du  = @. 5cos(5x)cos(7x) - 7sin(5x)sin(7x);
+    d2u = @. 5(-5sin(5x)cos(7x) -7cos(5x)sin(7x)) +
+           - 7(5cos(5x)sin(7x) + 7sin(5x)cos(7x))
 
     @test ≈(Dx * u, du; atol=1e-8)
+    @test ≈(D2x * u, d2u; atol=1e-8)
+
+    v = copy(u); @test ≈(mul!(v, D2x, u), d2u; atol=1e-8)
     v = copy(u); @test ≈(mul!(v, Dx, u), du; atol=1e-8)
 
     itr = inv(ftr)


### PR DESCRIPTION
Fix a bunch of silent errors that came up due to the changes in `cache_self` method for `ComposedOperator` (in 0.2.1). I only caught the bugs when I tested https://github.com/CalculustJL/FourierSpaces.jl. I'll add FourierSpaces as a downstream test in a follow up PR.

Also made some small fixes here and there.