### PR TITLE
fix warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -20,6 +20,20 @@ import SparseArrays: sparse, issparse
 
 """
 $(TYPEDEF)
+
+## Interface
+
+An `L::AbstractSciMLOperator` can be called like a function. This behaves
+like multiplication by the linear operator represented by the
+`AbstractSciMLOperator`. Possible signatures are
+
+- `L(du, u, p, t)` for in-place operator evaluation
+- `du = L(u, p, t)` for out-of-place operator evaluation
+
+If the operator is not a constant, update it with `(u, p, t)`.
+A mutating form, i.e. `update_coefficients!(L, u, p, t)` that changes the
+internal coefficients, and an out-of-place form
+`L_new = update_coefficients(L, u, p, t)`.
 """
 abstract type AbstractSciMLOperator{T} end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -3,18 +3,6 @@
 # Operator interface
 ###
 
-"""
-Function call and multiplication:
-    - L(du, u, p, t) for in-place operator evaluation,
-    - du = L(u, p, t) for out-of-place operator evaluation
-
-If the operator is not a constant, update it with (u,p,t). A mutating form, i.e.
-update_coefficients!(A,u,p,t) that changes the internal coefficients, and a
-out-of-place form B = update_coefficients(A,u,p,t).
-
-"""
-function (::AbstractSciMLOperator) end
-
 DEFAULT_UPDATE_FUNC(A,u,p,t) = A
 
 update_coefficients(L,u,p,t) = L
@@ -42,7 +30,7 @@ function iscached(L::AbstractSciMLOperator)
     has_cache = hasfield(typeof(L), :cache) # TODO - confirm this is static
     isset = has_cache ? !isnothing(L.cache) : true
 
-    return isset & all(iscached, getops(L)) 
+    return isset & all(iscached, getops(L))
 end
 
 iscached(L) = true


### PR DESCRIPTION
This fixes the warning
```julia
julia> using SciMLOperators
[ Info: Precompiling SciMLOperators [c0aeaf25-5076-4817-a8d5-81caf7dfa961]
┌ Warning: Replacing docs for `SciMLOperators.AbstractSciMLOperator :: Union{}` in module `SciMLOperators`
└ @ Base.Docs docs/Docs.jl:243
```

Without this patch, the docstring added in
https://github.com/SciML/SciMLOperators.jl/blob/1f8297b0d4c3f62c0f05007f38cd07b3fe12fdd7/src/SciMLOperators.jl#L21-L24
was overwritten (and not available anymore) for me.