### PR TITLE
Fix higher dimensional FunctionOperator size

### DIFF
--- a/src/func.jl
+++ b/src/func.jl
@@ -173,7 +173,7 @@ function FunctionOperator(op,
 
     # store eltype of input/output for caching with ComposedOperator.
     eltypes = eltype.((input, output))
-    sz = (size(output, 1), size(input, 1))
+    sz = (length(output), length(input))
     T  = isnothing(T) ? promote_type(eltypes...) : T
     t  = isnothing(t) ? zero(real(T)) : t
 


### PR DESCRIPTION
If a function operator takes in an MxNxO tensor and spits out an MxNxO tensor, then it's an MNO x MNO operator, not an MxM operator. It can be interpreted in the `vec(input)` -> `vec(output)` sense and thus `length` is the right measure to use. This fixes downstream use cases like:

```julia
using OrdinaryDiffEq, LinearAlgebra, Symbolics, LinearSolve

const N = 32
const xyd_brusselator = range(0,stop=1,length=N)
brusselator_f(x, y, t) = (((x-0.3)^2 + (y-0.6)^2) <= 0.1^2) * (t >= 1.1) * 5.
limit(a, N) = a == N+1 ? 1 : a == 0 ? N : a
function brusselator_2d_loop(du, u, p, t)
  A, B, alpha, dx = p
  alpha = alpha/dx^2
  @inbounds for I in CartesianIndices((N, N))
    i, j = Tuple(I)
    x, y = xyd_brusselator[I[1]], xyd_brusselator[I[2]]
    ip1, im1, jp1, jm1 = limit(i+1, N), limit(i-1, N), limit(j+1, N), limit(j-1, N)
    du[i,j,1] = alpha*(u[im1,j,1] + u[ip1,j,1] + u[i,jp1,1] + u[i,jm1,1] - 4u[i,j,1]) +
                B + u[i,j,1]^2*u[i,j,2] - (A + 1)*u[i,j,1] + brusselator_f(x, y, t)
    du[i,j,2] = alpha*(u[im1,j,2] + u[ip1,j,2] + u[i,jp1,2] + u[i,jm1,2] - 4u[i,j,2]) +
                A*u[i,j,1] - u[i,j,1]^2*u[i,j,2]
    end
end
p = (3.4, 1., 10., step(xyd_brusselator))

function init_brusselator_2d(xyd)
  N = length(xyd)
  u = zeros(N, N, 2)
  for I in CartesianIndices((N, N))
    x = xyd[I[1]]
    y = xyd[I[2]]
    u[I,1] = 22*(y*(1-y))^(3/2)
    u[I,2] = 27*(x*(1-x))^(3/2)
  end
  u
end
u0 = init_brusselator_2d(xyd_brusselator)
prob_ode_brusselator_2d = ODEProblem(brusselator_2d_loop,u0,(0.,11.5),p)

using Symbolics
du0 = copy(u0)
jac_sparsity = Symbolics.jacobian_sparsity((du,u)->brusselator_2d_loop(du,u,p,0.0),du0,u0)

f = ODEFunction(brusselator_2d_loop;jac_prototype=float.(jac_sparsity))
prob_ode_brusselator_2d_sparse = ODEProblem(f,u0,(0.,11.5),p)

sol1 = solve(prob_ode_brusselator_2d,KenCarp47(linsolve=LUFactorization()),save_everystep=false, reltol=1e-12, abstol=1e-12)
sol2 = solve(prob_ode_brusselator_2d,KenCarp47(linsolve=KrylovJL_GMRES(), concrete_jac = true),save_everystep=false, reltol=1e-12, abstol=1e-12)
sol3 = solve(prob_ode_brusselator_2d,KenCarp47(linsolve=KrylovJL_GMRES()),save_everystep=false, reltol=1e-12, abstol=1e-12)
@test norm(sol1[end] - sol2[end]) < 0.0002
@test norm(sol1[end] - sol3[end]) < 0.0002
@test norm(sol2[end] - sol3[end]) == 0.0
```