### PR TITLE
sum, prod fallbacks

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -384,17 +384,8 @@ for pred in (
              :isposdef,
             )
     @eval function LinearAlgebra.$pred(L::AbstractSciMLOperator)
-        @warn """using convert-based fallback in $pred."""
+        @warn """using convert-based fallback in $($pred)."""
         $pred(convert(AbstractMatrix, L))
-    end
-end
-
-for op in (
-           :sum,:prod
-          )
-    @eval function LinearAlgebra.$op(L::AbstractSciMLOperator; kwargs...)
-        @warn """using convert-based fallback in $op."""
-        $op(convert(AbstractMatrix, L); kwargs...)
     end
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -378,6 +378,15 @@ function LinearAlgebra.opnorm(L::AbstractSciMLOperator, p::Real=2)
     opnorm(convert(AbstractMatrix, L), p)
 end
 
+for op in (
+           :sum, :prod,
+          )
+    @eval function Base.$op(L::AbstractSciMLOperator; kwargs...)
+        @warn """using convert-based fallback in $($op)."""
+        $op(convert(AbstractMatrix, L); kwargs...)
+    end
+end
+
 for pred in (
              :issymmetric,
              :ishermitian,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -389,6 +389,15 @@ for pred in (
     end
 end
 
+for op in (
+           :sum,:prod
+          )
+    @eval function LinearAlgebra.$op(L::AbstractSciMLOperator; kwargs...)
+        @warn """using convert-based fallback in $op."""
+        $op(convert(AbstractMatrix, L); kwargs...)
+    end
+end
+
 function LinearAlgebra.mul!(v::AbstractArray, L::AbstractSciMLOperator, u::AbstractArray)
     @warn """using convert-based fallback in mul!."""
     mul!(v, convert(AbstractMatrix, L), u)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -389,15 +389,6 @@ for pred in (
     end
 end
 
-for op in (
-           :sum,:prod
-          )
-    @eval function LinearAlgebra.$op(L::AbstractSciMLOperator; kwargs...)
-        @warn """using convert-based fallback in $op."""
-        $op(convert(AbstractMatrix, L); kwargs...)
-    end
-end
-
 function LinearAlgebra.mul!(v::AbstractArray, L::AbstractSciMLOperator, u::AbstractArray)
     @warn """using convert-based fallback in mul!."""
     mul!(v, convert(AbstractMatrix, L), u)


### PR DESCRIPTION
Add back fallback methods in https://github.com/SciML/SciMLOperators.jl/pull/208

fix https://github.com/SciML/SciMLOperators.jl/actions/runs/5437055376/jobs/9887334855#step:6:1143

with this branch,

```julia
julia> using SciMLOperators

julia> A = MatrixOperator(rand(4,4));

julia> B = A + A \ A * A
(MatrixOperator(4 × 4) + (1 / MatrixOperator(4 × 4) * MatrixOperator(4 × 4) * MatrixOperator(4 × 4)))

julia> sum(A)
┌ Warning: using convert-based fallback in sum.
└ @ SciMLOperators ~/.julia/dev/SciMLOperators/src/interface.jl:385
7.445259168454413

julia> sum(A; dims = 1)
┌ Warning: using convert-based fallback in sum.
└ @ SciMLOperators ~/.julia/dev/SciMLOperators/src/interface.jl:385
1×4 Matrix{Float64}:
 1.31282  2.63051  1.71377  1.78816
```

ODE/InterfaceII tests passing locally with this branch.