### PR TITLE
allow functionoperator (batch = false) to accept/return vec'd arrays

### DIFF
--- a/src/func.jl
+++ b/src/func.jl
@@ -619,9 +619,9 @@ function _unvec(L::FunctionOperator, u, v)
 
         if !isnothing(u) & !isnothing(v)
             if (vec_u & !vec_v) | (!vec_u & vec_v)
-                msg = """Input/output to $L can either be of sizes
-                    $(sizes[1])/ $(sizes[2]), or
-                    $(tuple(prod(sizes[1])))/ $(tuple(prod(sizes[2]))). Got
+                msg = """Input / output to $L can either be of sizes
+                    $(sizes[1]) / $(sizes[2]), or
+                    $(tuple(prod(sizes[1]))) / $(tuple(prod(sizes[2]))). Got
                     $(size(u)), $(size(v))."""
                 throw(DimensionMismatch(msg))
             end

--- a/test/func.jl
+++ b/test/func.jl
@@ -47,13 +47,25 @@ NK = N * K
         L = FunctionOperator(f, u, v; kw...)
         L = cache_operator(L, u)
 
+        # test with ND-arrays
         @test _mul(A, u) ≈ L(u, p, t) ≈ L * u ≈ mul!(zero(v), L, u)
         @test α * _mul(A, u)+ β * v ≈ mul!(copy(v), L, u, α, β)
 
         if sz_in == sz_out
             @test _div(A, v) ≈ L \ v ≈ ldiv!(zero(u), L, v) ≈ ldiv!(L, copy(v))
         end
-    end
+
+        # test with vec(Array)
+        @test vec(_mul(A, u)) ≈ L(vec(u), p, t) ≈ L * vec(u) ≈ mul!(vec(zero(v)), L, vec(u))
+        @test vec(α * _mul(A, u)+ β * v) ≈ mul!(vec(copy(v)), L, vec(u), α, β)
+
+        if sz_in == sz_out
+            @test vec(_div(A, v)) ≈ L \ vec(v) ≈ ldiv!(vec(zero(u)), L, vec(v)) ≈ ldiv!(L, vec(copy(v)))
+        end
+
+        @test_throws DimensionMismatch mul!(vec(v), L, u)
+        @test_throws DimensionMismatch mul!(v, L, vec(u))
+    end # for
 
 end
 


### PR DESCRIPTION
@ChrisRackauckas 

with this branch,

```julia
julia> f(u, p, t) = 2u; f(v, u, p, t) = mul!(v, 2, u);                                                                                                               [30/1927]
                                           
julia> F = FunctionOperator(f, ones(4, 4));
                                           
julia> F * ones(4, 4)
4×4 Matrix{Float64}:
 2.0  2.0  2.0  2.0
 2.0  2.0  2.0  2.0
 2.0  2.0  2.0  2.0
 2.0  2.0  2.0  2.0                        

julia> F * vec(ones(4, 4))
16-element Vector{Float64}:
 2.0
 2.0
 2.0
 2.0
 2.0
...
julia> mul!(zeros(16), F, ones(16))
16-element Vector{Float64}:
 2.0
 2.0
 2.0
 2.0
 2.0
...

```