### PR TITLE
Aqua CI

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -79,6 +79,11 @@ for op in (:*, :∘)
         @assert size(A, 2) == ii.len
         A
     end
+
+    @eval function Base.$op(ii1::IdentityOperator, ii2::IdentityOperator)
+        @assert ii1.len == ii2.len
+        IdentityOperator(ii1.len)
+    end
 end
 
 function Base.:\(ii::IdentityOperator, A::AbstractSciMLOperator)
@@ -156,6 +161,35 @@ for op in (:*, :∘)
         @assert size(A, 2) == nn.len
         NullOperator(nn.len)
     end
+
+    @eval function Base.$op(nn1::NullOperator, nn2::NullOperator)
+        @assert nn1.len == nn2.len
+        NullOperator(nn1.len)
+    end
+
+    @eval function Base.$op(nn::NullOperator, ii::IdentityOperator)
+        @assert nn.len == ii.len
+        NullOperator(nn.len)
+    end
+
+    @eval function Base.$op(ii::IdentityOperator, nn::NullOperator)
+        @assert nn.len == ii.len
+        NullOperator(nn.len)
+    end
+
+    @eval function Base.$op(nn::NullOperator, ii::IdentityOperator)
+        @assert nn.len == ii.len
+        NullOperator(nn.len)
+    end
+
+    @eval function Base.$op(λ::AbstractSciMLScalarOperator, nn::NullOperator)
+        NullOperator(nn.len)
+    end
+
+    @eval function Base.$op(nn::NullOperator, λ::AbstractSciMLScalarOperator)
+        NullOperator(nn.len)
+    end
+
 end
 
 # operator addition, subtraction with NullOperator returns operator itself
@@ -169,6 +203,12 @@ for op in (:+, :-)
         @assert size(A) == (nn.len, nn.len)
         A
     end
+
+    @eval function Base.$op(nn1::NullOperator, nn2::NullOperator)
+        @assert nn1.len == nn2.len
+        nn1
+    end
+
 end
 
 """

--- a/src/func.jl
+++ b/src/func.jl
@@ -533,7 +533,7 @@ function Base.resize!(L::FunctionOperator, n::Integer)
     L
 end
 
-function LinearAlgebra.opnorm(L::FunctionOperator, p)
+function LinearAlgebra.opnorm(L::FunctionOperator, p::Real)
     L.traits.opnorm === nothing && error("""
       M.opnorm is nothing, please define opnorm as a function that takes one
       argument. E.g., `(p::Real) -> p == Inf ? 100 : error("only Inf norm is

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -335,7 +335,7 @@ Base.transpose(L::InvertibleOperator) = InvertibleOperator(transpose(L.L), trans
 Base.adjoint(L::InvertibleOperator) = InvertibleOperator(L.L', L.F')
 Base.conj(L::InvertibleOperator) = InvertibleOperator(conj(L.L), conj(L.F))
 Base.resize!(L::InvertibleOperator, n::Integer) = (resize!(L.L, n); resize!(L.F, n); L)
-LinearAlgebra.opnorm(L::InvertibleOperator{T}, p = 2) where {T} = one(T) / opnorm(L.F)
+LinearAlgebra.opnorm(L::InvertibleOperator{T}, p::Real = 2) where {T} = one(T) / opnorm(L.F)
 LinearAlgebra.issuccess(L::InvertibleOperator) = issuccess(L.F)
 
 function update_coefficients(L::InvertibleOperator, u, p, t)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -6,3 +7,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[compat]
+Aqua = "0.8"

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -1,0 +1,12 @@
+using SciMLOperators, Aqua
+@testset "Aqua" begin
+    Aqua.find_persistent_tasks_deps(SciMLOperators)
+    Aqua.test_ambiguities(SciMLOperators, recursive = false)
+    Aqua.test_deps_compat(SciMLOperators)
+    Aqua.test_piracies(SciMLOperators,
+        treat_as_own = [])
+    Aqua.test_project_extras(SciMLOperators)
+    Aqua.test_stale_deps(SciMLOperators)
+    Aqua.test_unbound_args(SciMLOperators)
+    Aqua.test_undefined_exports(SciMLOperators)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using SafeTestsets
 
 @time begin
+    @time @safetestset "Quality Assurance" begin
+        include("qa.jl")
+    end
     @time @safetestset "Scalar Operators" begin
         include("scalar.jl")
     end


### PR DESCRIPTION
This package has quite a few method ambiguities that can get called in practice.
I already tried my hand at resolving some of them.
Things I'm still unsure about:

- How does `opnorm` work right now? To me, it seems like the standard way of calling it would result in the ambiguity.
- What `+(::SciMLOperators.NullOperator, ::SciMLOperators.AbstractSciMLScalarOperator)` should result in. A matrix operator which is equivalent to a scaled identity matrix?
- No idea at all about `+(::SciMLOperators.AddedOperator, ::SciMLOperators.AbstractSciMLScalarOperator)`