### PR TITLE
Remove Packages that are no longer needed in 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,6 @@ jobs:
           - Core
         version:
           - '1'
-          - '1.6'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -13,7 +13,7 @@ jobs:
       GROUP: ${{ matrix.package.group }}
     strategy:
       matrix:
-        julia-version: [1,1.6]
+        julia-version: [1]
         os: [ubuntu-latest]
         package:
           - {user: SciML, repo: SciMLBase.jl, group: InterfaceII}

--- a/Project.toml
+++ b/Project.toml
@@ -1,25 +1,23 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [compat]
 ArrayInterface = "7"
 DocStringExtensions = "0.8, 0.9"
-Lazy = "0.15"
 LinearAlgebra = "1.6"
+MacroTools = "0.5"
 Setfield = "0.8, 1"
-StaticArraysCore = "1"
 SparseArrays = "1.6"
-Tricks = "0.1.6"
-julia = "1.6"
+StaticArraysCore = "1"
+julia = "1.10"

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -9,8 +9,7 @@ using LinearAlgebra
 import SparseArrays
 import StaticArraysCore
 import ArrayInterface
-import Tricks: static_hasmethod
-import Lazy: @forward
+import MacroTools: @forward
 import Setfield: @set!
 
 # overload

--- a/src/func.jl
+++ b/src/func.jl
@@ -265,7 +265,7 @@ function FunctionOperator(op,
     # evaluation signatures
 
     _isinplace = if isinplace === nothing
-        Val(static_hasmethod(op, typeof((output, input, p, _t))))
+        Val(hasmethod(op, typeof((output, input, p, _t))))
     elseif isinplace isa Bool
         Val(isinplace)
     else
@@ -273,7 +273,7 @@ function FunctionOperator(op,
     end
 
     _outofplace = if outofplace === nothing
-        Val(static_hasmethod(op, typeof((input, p, _t))))
+        Val(hasmethod(op, typeof((input, p, _t))))
     elseif outofplace isa Bool
         Val(outofplace)
     else
@@ -342,7 +342,7 @@ end
 
 @inline __has_mul5(::Nothing, y, x, p, t) = Val(true)
 @inline function __has_mul5(f::F, y, x, p, t) where {F}
-    return Val(static_hasmethod(f, typeof((y, x, p, t, t, t))))
+    return Val(hasmethod(f, typeof((y, x, p, t, t, t))))
 end
 @inline __and_val(vs...) = mapreduce(_unwrap_val, *, vs)
 
@@ -542,7 +542,7 @@ function Base.resize!(L::FunctionOperator, n::Integer)
     end
 
     for op in getops(L)
-        if static_hasmethod(resize!, typeof((op, n)))
+        if hasmethod(resize!, typeof((op, n)))
             resize!(op, n)
         end
     end


### PR DESCRIPTION
After that entire discussion on slack regarding SimpleNonlinearSolve precompile times. It seems we are installing packages that are not needed in 1.10+.

This + some SciMLBase changes:

```julia
# OLD
julia> @time using SciMLOperators, SciMLBase
  0.137750 seconds (160.93 k allocations: 16.369 MiB)

# NEW
julia> @time using SciMLOperators, SciMLBase
  0.090675 seconds (113.75 k allocations: 13.515 MiB)
```