### PR TITLE
migrate to Accessors, move StaticArraysCore to ext

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,18 +8,22 @@ ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 
 [weakdeps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+
+[extensions]
+SciMLOperatorsSparseArraysExt = "SparseArrays"
+SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
 [compat]
+Accessors = "1"
 ArrayInterface = "7"
 DocStringExtensions = "0.8, 0.9"
 LinearAlgebra = "1.6"
 MacroTools = "0.5"
-Setfield = "0.8, 1"
 SparseArrays = "1.6"
 StaticArraysCore = "1"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ SciMLOperatorsSparseArraysExt = "SparseArrays"
 SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
 [compat]
-Accessors = "1"
+Accessors = "0.1"
 ArrayInterface = "7"
 DocStringExtensions = "0.8, 0.9"
 LinearAlgebra = "1.6"

--- a/ext/SciMLOperatorsStaticArraysCoreExt.jl
+++ b/ext/SciMLOperatorsStaticArraysCoreExt.jl
@@ -1,0 +1,11 @@
+module SciMLOperatorsStaticArraysCoreExt
+
+import SciMLOperators
+import StaticArraysCore
+
+function Base.copyto!(L::SciMLOperators.MatrixOperator,
+    rhs::Base.Broadcast.Broadcasted{<:StaticArraysCore.StaticArrayStyle})
+(copyto!(L.A, rhs); L)
+end
+
+end #module

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -7,10 +7,9 @@ using DocStringExtensions
 
 using LinearAlgebra
 
-import StaticArraysCore
 import ArrayInterface
 import MacroTools: @forward
-import Setfield: @set!
+import Accessors: @set
 
 # overload
 import Base: show

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -9,7 +9,7 @@ using LinearAlgebra
 
 import ArrayInterface
 import MacroTools: @forward
-import Accessors: @set
+import Accessors: @reset
 
 # overload
 import Base: show

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -240,8 +240,8 @@ Base.resize!(L::ScaledOperator, n::Integer) = (resize!(L.L, n); L)
 LinearAlgebra.opnorm(L::ScaledOperator, p::Real = 2) = abs(L.λ) * opnorm(L.L, p)
 
 function update_coefficients(L::ScaledOperator, u, p, t)
-    @set! L.L = update_coefficients(L.L, u, p, t)
-    @set! L.λ = update_coefficients(L.λ, u, p, t)
+    @reset L.L = update_coefficients(L.L, u, p, t)
+    @reset L.λ = update_coefficients(L.λ, u, p, t)
 
     L
 end
@@ -256,8 +256,8 @@ has_ldiv(L::ScaledOperator) = has_ldiv(L.L) & !iszero(L.λ)
 has_ldiv!(L::ScaledOperator) = has_ldiv!(L.L) & !iszero(L.λ)
 
 function cache_internals(L::ScaledOperator, u::AbstractVecOrMat)
-    @set! L.L = cache_operator(L.L, u)
-    @set! L.λ = cache_operator(L.λ, u)
+    @reset L.L = cache_operator(L.L, u)
+    @reset L.λ = cache_operator(L.λ, u)
     L
 end
 
@@ -411,7 +411,7 @@ function update_coefficients(L::AddedOperator, u, p, t)
         ops = (ops..., update_coefficients(op, u, p, t))
     end
 
-    @set! L.ops = ops
+    @reset L.ops = ops
 end
 
 getops(L::AddedOperator) = L.ops
@@ -421,7 +421,7 @@ has_adjoint(L::AddedOperator) = all(has_adjoint, L.ops)
 
 function cache_internals(L::AddedOperator, u::AbstractVecOrMat)
     for i in 1:length(L.ops)
-        @set! L.ops[i] = cache_operator(L.ops[i], u)
+        @reset L.ops[i] = cache_operator(L.ops[i], u)
     end
     L
 end
@@ -576,7 +576,7 @@ function update_coefficients(L::ComposedOperator, u, p, t)
         ops = (ops..., update_coefficients(op, u, p, t))
     end
 
-    @set! L.ops = ops
+    @reset L.ops = ops
 end
 
 getops(L::ComposedOperator) = L.ops
@@ -646,7 +646,7 @@ function cache_self(L::ComposedOperator, u::AbstractVecOrMat)
         cache = (similar(u, T, sz), cache...)
     end
 
-    @set! L.cache = cache
+    @reset L.cache = cache
     L
 end
 
@@ -660,7 +660,7 @@ function cache_internals(L::ComposedOperator, u::AbstractVecOrMat)
         ops = (cache_operator(L.ops[i], L.cache[i]), ops...)
     end
 
-    @set! L.ops = ops
+    @reset L.ops = ops
 end
 
 function LinearAlgebra.mul!(v::AbstractVecOrMat, L::ComposedOperator, u::AbstractVecOrMat)
@@ -757,7 +757,7 @@ function Base.resize!(L::InvertedOperator, n::Integer)
 end
 
 function update_coefficients(L::InvertedOperator, u, p, t)
-    @set! L.L = update_coefficients(L.L, u, p, t)
+    @reset L.L = update_coefficients(L.L, u, p, t)
 
     L
 end
@@ -787,12 +787,12 @@ Base.:\(L::InvertedOperator, u::AbstractVecOrMat) = L.L * u
 
 function cache_self(L::InvertedOperator, u::AbstractVecOrMat)
     cache = zero(u)
-    @set! L.cache = cache
+    @reset L.cache = cache
     L
 end
 
 function cache_internals(L::InvertedOperator, u::AbstractVecOrMat)
-    @set! L.L = cache_operator(L.L, u)
+    @reset L.L = cache_operator(L.L, u)
     L
 end
 

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -83,7 +83,7 @@ end
 LinearAlgebra.isposdef(L::BatchedDiagonalOperator) = isposdef(Diagonal(vec(L.diag)))
 
 function update_coefficients(L::BatchedDiagonalOperator, u, p, t; kwargs...)
-    @set! L.diag = L.update_func(L.diag, u, p, t; kwargs...)
+    @reset L.diag = L.update_func(L.diag, u, p, t; kwargs...)
 end
 
 function update_coefficients!(L::BatchedDiagonalOperator, u, p, t; kwargs...)

--- a/src/left.jl
+++ b/src/left.jl
@@ -121,7 +121,7 @@ for (op, LType, VType) in ((:adjoint, :AdjointOperator, :AbstractAdjointVecOrMat
         has_ldiv!)
 
     @eval function cache_internals(L::$LType, u::AbstractVecOrMat)
-        @set! L.L = cache_operator(L.L, reshape(u, size(L, 1)))
+        @reset L.L = cache_operator(L.L, reshape(u, size(L, 1)))
         L
     end
 

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -156,7 +156,7 @@ function isconstant(L::MatrixOperator)
 end
 
 function update_coefficients(L::MatrixOperator, u, p, t; kwargs...)
-    @set! L.A = L.update_func(L.A, u, p, t; kwargs...)
+    @reset L.A = L.update_func(L.A, u, p, t; kwargs...)
 end
 
 function update_coefficients!(L::MatrixOperator, u, p, t; kwargs...)
@@ -181,10 +181,7 @@ function Base.IndexStyle(::Type{<:MatrixOperator{T, AType}}) where {T, AType}
     Base.IndexStyle(AType)
 end
 Base.copyto!(L::MatrixOperator, rhs) = (copyto!(L.A, rhs); L)
-function Base.copyto!(L::MatrixOperator,
-        rhs::Base.Broadcast.Broadcasted{<:StaticArraysCore.StaticArrayStyle})
-    (copyto!(L.A, rhs); L)
-end
+
 Base.Broadcast.broadcastable(L::MatrixOperator) = L
 Base.ndims(::Type{<:MatrixOperator{T, AType}}) where {T, AType} = ndims(AType)
 ArrayInterface.issingular(L::MatrixOperator) = ArrayInterface.issingular(L.A)
@@ -337,8 +334,8 @@ LinearAlgebra.opnorm(L::InvertibleOperator{T}, p = 2) where {T} = one(T) / opnor
 LinearAlgebra.issuccess(L::InvertibleOperator) = issuccess(L.F)
 
 function update_coefficients(L::InvertibleOperator, u, p, t)
-    @set! L.L = update_coefficients(L.L, u, p, t)
-    @set! L.F = update_coefficients(L.F, u, p, t)
+    @reset L.L = update_coefficients(L.L, u, p, t)
+    @reset L.F = update_coefficients(L.F, u, p, t)
     L
 end
 
@@ -362,8 +359,8 @@ has_ldiv(L::InvertibleOperator) = has_mul(L.F)
 has_ldiv!(L::InvertibleOperator) = has_ldiv!(L.F)
 
 function cache_internals(L::InvertibleOperator, u::AbstractVecOrMat)
-    @set! L.L = cache_operator(L.L, u)
-    @set! L.F = cache_operator(L.F, u)
+    @reset L.L = cache_operator(L.L, u)
+    @reset L.F = cache_operator(L.F, u)
 
     L
 end
@@ -515,9 +512,9 @@ function AddVector(B, b::AbstractVecOrMat;
 end
 
 function update_coefficients(L::AffineOperator, u, p, t; kwargs...)
-    @set! L.A = update_coefficients(L.A, u, p, t; kwargs...)
-    @set! L.B = update_coefficients(L.B, u, p, t; kwargs...)
-    @set! L.b = L.update_func(L.b, u, p, t; kwargs...)
+    @reset L.A = update_coefficients(L.A, u, p, t; kwargs...)
+    @reset L.B = update_coefficients(L.B, u, p, t; kwargs...)
+    @reset L.b = L.update_func(L.b, u, p, t; kwargs...)
 end
 
 function update_coefficients!(L::AffineOperator, u, p, t; kwargs...)
@@ -577,8 +574,8 @@ has_ldiv(L::AffineOperator) = has_ldiv(L.A)
 has_ldiv!(L::AffineOperator) = has_ldiv!(L.A)
 
 function cache_internals(L::AffineOperator, u::AbstractVecOrMat)
-    @set! L.A = cache_operator(L.A, u)
-    @set! L.B = cache_operator(L.B, L.b)
+    @reset L.A = cache_operator(L.A, u)
+    @reset L.B = cache_operator(L.B, L.b)
     L
 end
 

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -194,7 +194,7 @@ function update_coefficients!(L::ScalarOperator, u, p, t; kwargs...)
 end
 
 function update_coefficients(L::ScalarOperator, u, p, t; kwargs...)
-    @set! L.val = L.update_func(L.val, u, p, t; kwargs...)
+    @reset L.val = L.update_func(L.val, u, p, t; kwargs...)
 end
 
 """
@@ -262,7 +262,7 @@ function update_coefficients(L::AddedScalarOperator, u, p, t)
         ops = (ops..., update_coefficients(op, u, p, t))
     end
 
-    @set! L.ops = ops
+    @reset L.ops = ops
 end
 
 getops(α::AddedScalarOperator) = α.ops
@@ -336,7 +336,7 @@ function update_coefficients(L::ComposedScalarOperator, u, p, t)
         ops = (ops..., update_coefficients(op, u, p, t))
     end
 
-    @set! L.ops = ops
+    @reset L.ops = ops
 end
 
 getops(α::ComposedScalarOperator) = α.ops
@@ -393,7 +393,7 @@ end
 Base.conj(L::InvertedScalarOperator) = InvertedScalarOperator(conj(L.λ))
 
 function update_coefficients(L::InvertedScalarOperator, u, p, t)
-    @set! L.λ = update_coefficients(L.λ, u, p, t)
+    @reset L.λ = update_coefficients(L.λ, u, p, t)
     L
 end
 

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -110,7 +110,7 @@ function update_coefficients(L::TensorProductOperator, u, p, t)
         ops = (ops..., update_coefficients(op, u, p, t))
     end
 
-    @set! L.ops = ops
+    @reset L.ops = ops
 end
 
 getops(L::TensorProductOperator) = L.ops
@@ -182,7 +182,7 @@ function cache_self(L::TensorProductOperator, u::AbstractVecOrMat)
         c7 = lmul!(false, similar(u, (no, ni * k))) # c7 = outer \ c6
     end
 
-    @set! L.cache = (c1, c2, c3, c4, c5, c6, c7)
+    @reset L.cache = (c1, c2, c3, c4, c5, c6, c7)
     L
 end
 
@@ -200,8 +200,8 @@ function cache_internals(L::TensorProductOperator, u::AbstractVecOrMat)
     uinner = reshape(u, (ni, no * k))
     uouter = reshape(L.cache[2], (no, mi * k))
 
-    @set! L.ops[2] = cache_operator(inner, uinner)
-    @set! L.ops[1] = cache_operator(outer, uouter)
+    @reset L.ops[2] = cache_operator(inner, uinner)
+    @reset L.ops[1] = cache_operator(outer, uouter)
     L
 end
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
I saw that SciMLBase depends both on Accessors and SetField. this PR migrates the uses of SetField to Accessors, and moves StaticArraysCore to an extension (in this way, StaticArraysCore is not loaded anymore)
