### PR TITLE
Add missing inplace update_coefficients for `ScaledOperator`

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -245,6 +245,14 @@ function update_coefficients(L::ScaledOperator, u, p, t)
 
     L
 end
+
+function update_coefficients!(L::ScaledOperator, u, p, t)
+    update_coefficients!(L.L, u, p, t)
+    update_coefficients!(L.λ, u, p, t)
+
+    L
+end
+
 getops(L::ScaledOperator) = (L.λ, L.L)
 isconstant(L::ScaledOperator) = isconstant(L.L) & isconstant(L.λ)
 islinear(L::ScaledOperator) = islinear(L.L)


### PR DESCRIPTION
This PR fixes #247.

A dedicated `update_coefficients!` method for in-place update of `ScaledOperator` was missing.

I've just added that method.
