### PR TITLE
Remove `Dict{Symbol, Any}` for type stability in `FunctionOperator`

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -49,7 +49,7 @@ function LinearAlgebra.mul!(v::AbstractVecOrMat, ii::IdentityOperator, u::Abstra
     copy!(v, u)
 end
 
-function LinearAlgebra.mul!(v::AbstractVecOrMat,
+@inline function LinearAlgebra.mul!(v::AbstractVecOrMat,
         ii::IdentityOperator,
         u::AbstractVecOrMat,
         α,

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -44,7 +44,8 @@ for op in (:*, :\)
     end
 end
 
-function LinearAlgebra.mul!(v::AbstractVecOrMat, ii::IdentityOperator, u::AbstractVecOrMat)
+@inline function LinearAlgebra.mul!(
+        v::AbstractVecOrMat, ii::IdentityOperator, u::AbstractVecOrMat)
     @assert size(u, 1) == ii.len
     copy!(v, u)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,6 +42,11 @@ function get_filtered_kwargs(kwargs::AbstractDict,
         accepted_kwargs::NTuple{N, Symbol}) where {N}
     (kw => kwargs[kw] for kw in accepted_kwargs if haskey(kwargs, kw))
 end
+function get_filtered_kwargs(kwargs::Union{AbstractDict, NamedTuple},
+        ::Val{accepted_kwargs}) where {accepted_kwargs}
+    kwargs_nt = NamedTuple(kwargs)
+    return NamedTuple{accepted_kwargs}(kwargs_nt)  # This creates a new NamedTuple with keys specified by `accepted_kwargs`
+end
 
 function (f::FilterKwargs)(args...; kwargs...)
     filtered_kwargs = get_filtered_kwargs(kwargs, f.accepted_kwargs)

--- a/test/func.jl
+++ b/test/func.jl
@@ -257,6 +257,10 @@ end
     f(u, p, t; scale = 1.0) = Diagonal(p * t * scale) * u
 
     L = FunctionOperator(f, u, u; p = zero(p), t = zero(t), batch = true,
+        accepted_kwargs = (:scale,), scale = 1.0)
+
+    @test_throws ArgumentError FunctionOperator(
+        f, u, u; p = zero(p), t = zero(t), batch = true,
         accepted_kwargs = (:scale,))
 
     @test size(L) == (N, N)

--- a/test/func.jl
+++ b/test/func.jl
@@ -305,5 +305,57 @@ end
     @test v2 ≈ a2 * A * u2 + b2 * w2
     @test v1 ≈ a1 * A * u1 + b1 * w1
     @test v1 + v2 ≈ (a1 * A * u1 + b1 * w1) + (a2 * A * u2 + b2 * w2)
+
+    ## Do the same with Val((:scale,))
+
+    L = FunctionOperator(f, u, u; p = zero(p), t = zero(t), batch = true,
+        accepted_kwargs = Val((:scale,)), scale = 1.0)
+
+    @test_throws ArgumentError FunctionOperator(
+        f, u, u; p = zero(p), t = zero(t), batch = true,
+        accepted_kwargs = Val((:scale,)))
+
+    @test size(L) == (N, N)
+
+    ans = @. u * p * t * scale
+    @test L(u, p, t; scale) ≈ ans
+    v = copy(u)
+    @test L(v, u, p, t; scale) ≈ ans
+
+    # test that output isn't accidentally mutated by passing an internal cache.
+
+    A = Diagonal(p * t * scale)
+    u1 = rand(N, K)
+    u2 = rand(N, K)
+
+    v1 = L * u1
+    @test v1 ≈ A * u1
+    v2 = L * u2
+    @test v2 ≈ A * u2
+    @test v1 ≈ A * u1
+    @test v1 + v2 ≈ A * (u1 + u2)
+
+    v1 .= 0.0
+    v2 .= 0.0
+
+    mul!(v1, L, u1)
+    @test v1 ≈ A * u1
+    mul!(v2, L, u2)
+    @test v2 ≈ A * u2
+    @test v1 ≈ A * u1
+    @test v1 + v2 ≈ A * (u1 + u2)
+
+    v1 = rand(N, K)
+    w1 = copy(v1)
+    v2 = rand(N, K)
+    w2 = copy(v2)
+    a1, a2, b1, b2 = rand(4)
+
+    mul!(v1, L, u1, a1, b1)
+    @test v1 ≈ a1 * A * u1 + b1 * w1
+    mul!(v2, L, u2, a2, b2)
+    @test v2 ≈ a2 * A * u2 + b2 * w2
+    @test v1 ≈ a1 * A * u1 + b1 * w1
+    @test v1 + v2 ≈ (a1 * A * u1 + b1 * w1) + (a2 * A * u2 + b2 * w2)
 end
 #

--- a/test/func.jl
+++ b/test/func.jl
@@ -256,55 +256,57 @@ end
     f(du, u, p, t; scale = 1.0) = mul!(du, Diagonal(p * t * scale), u)
     f(u, p, t; scale = 1.0) = Diagonal(p * t * scale) * u
 
-    L = FunctionOperator(f, u, u; p = zero(p), t = zero(t), batch = true,
-        accepted_kwargs = (:scale,), scale = 1.0)
+    for acc_kw in ((:scale,), Val((:scale,)))
+        L = FunctionOperator(f, u, u; p = zero(p), t = zero(t), batch = true,
+            accepted_kwargs = acc_kw, scale = 1.0)
 
-    @test_throws ArgumentError FunctionOperator(
-        f, u, u; p = zero(p), t = zero(t), batch = true,
-        accepted_kwargs = (:scale,))
+        @test_throws ArgumentError FunctionOperator(
+            f, u, u; p = zero(p), t = zero(t), batch = true,
+            accepted_kwargs = acc_kw)
 
-    @test size(L) == (N, N)
+        @test size(L) == (N, N)
 
-    ans = @. u * p * t * scale
-    @test L(u, p, t; scale) ≈ ans
-    v = copy(u)
-    @test L(v, u, p, t; scale) ≈ ans
+        ans = @. u * p * t * scale
+        @test L(u, p, t; scale) ≈ ans
+        v = copy(u)
+        @test L(v, u, p, t; scale) ≈ ans
 
-    # test that output isn't accidentally mutated by passing an internal cache.
+        # test that output isn't accidentally mutated by passing an internal cache.
 
-    A = Diagonal(p * t * scale)
-    u1 = rand(N, K)
-    u2 = rand(N, K)
+        A = Diagonal(p * t * scale)
+        u1 = rand(N, K)
+        u2 = rand(N, K)
 
-    v1 = L * u1
-    @test v1 ≈ A * u1
-    v2 = L * u2
-    @test v2 ≈ A * u2
-    @test v1 ≈ A * u1
-    @test v1 + v2 ≈ A * (u1 + u2)
+        v1 = L * u1
+        @test v1 ≈ A * u1
+        v2 = L * u2
+        @test v2 ≈ A * u2
+        @test v1 ≈ A * u1
+        @test v1 + v2 ≈ A * (u1 + u2)
 
-    v1 .= 0.0
-    v2 .= 0.0
+        v1 .= 0.0
+        v2 .= 0.0
 
-    mul!(v1, L, u1)
-    @test v1 ≈ A * u1
-    mul!(v2, L, u2)
-    @test v2 ≈ A * u2
-    @test v1 ≈ A * u1
-    @test v1 + v2 ≈ A * (u1 + u2)
+        mul!(v1, L, u1)
+        @test v1 ≈ A * u1
+        mul!(v2, L, u2)
+        @test v2 ≈ A * u2
+        @test v1 ≈ A * u1
+        @test v1 + v2 ≈ A * (u1 + u2)
 
-    v1 = rand(N, K)
-    w1 = copy(v1)
-    v2 = rand(N, K)
-    w2 = copy(v2)
-    a1, a2, b1, b2 = rand(4)
+        v1 = rand(N, K)
+        w1 = copy(v1)
+        v2 = rand(N, K)
+        w2 = copy(v2)
+        a1, a2, b1, b2 = rand(4)
 
-    mul!(v1, L, u1, a1, b1)
-    @test v1 ≈ a1 * A * u1 + b1 * w1
-    mul!(v2, L, u2, a2, b2)
-    @test v2 ≈ a2 * A * u2 + b2 * w2
-    @test v1 ≈ a1 * A * u1 + b1 * w1
-    @test v1 + v2 ≈ (a1 * A * u1 + b1 * w1) + (a2 * A * u2 + b2 * w2)
+        mul!(v1, L, u1, a1, b1)
+        @test v1 ≈ a1 * A * u1 + b1 * w1
+        mul!(v2, L, u2, a2, b2)
+        @test v2 ≈ a2 * A * u2 + b2 * w2
+        @test v1 ≈ a1 * A * u1 + b1 * w1
+        @test v1 + v2 ≈ (a1 * A * u1 + b1 * w1) + (a2 * A * u2 + b2 * w2)
+    end
 
     ## Do the same with Val((:scale,))
 


### PR DESCRIPTION
The current implementation of `FunctionOperator` requires a `Dict{Symbol,Any}` to handle the keyword arguments. This leads to type instabilities and performance decreases, as in the following simple code:

```julia
using LinearAlgebra
using BenchmarkTools
using SciMLOperators

T = ComplexF64
N = 10

u = rand(T, N)
du = similar(u)
p = (A=rand(T, N, N),)

op = FunctionOperator((du, u, p, t) -> mul!(du, p.A, u), u, p = p, T=T, isinplace=Val(true), outofplace=Val(true), has_mul5=Val(true), isconstant=true)

op(du, u, p, 0.1)

@benchmark $op($du, $u, $p, 0.1)
```

### master branch
```julia-repl
BenchmarkTools.Trial: 10000 samples with 53 evaluations.
 Range (min … max):  864.434 ns … 104.262 μs  ┊ GC (min … max): 0.00% … 98.52%
 Time  (median):     947.340 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   996.750 ns ±   1.294 μs  ┊ GC (mean ± σ):  2.57% ±  2.17%

           ▃█                                                    
  ▂▂▃▅▄▃▃▃▅███▄▃▃▃▃▃▃▃▃▄▅▄▄▃▂▂▂▂▂▂▂▂▂▂▂▁▂▁▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂ ▃
  864 ns           Histogram: frequency by time         1.34 μs <

 Memory estimate: 560 bytes, allocs estimate: 7.
```

### This PR branch

```julia-repl
BenchmarkTools.Trial: 10000 samples with 989 evaluations.
 Range (min … max):  46.024 ns … 64.056 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     48.916 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   48.858 ns ±  1.040 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▃▄▄▂  ▁▁▁▂▂▂▂▁    ▁▁▁▁▁▁▁▁▁ ▁▂▃▆▇█▇▆▅▄▅▅▅▅▅▅▄▄▄▁▁▁▁▁▁▂▂▁▁  ▃
  ▇██████████████████████████████████████████████████████████ █
  46 ns        Histogram: log(frequency) by time      50.9 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

---

To manage to fix this issue, I used `NamedTuple` instead of `Dict{Symbol, Any}`. For this reason, the additional `kwargs` are required when `accepted_kwargs` is provided, in order to initialize the types inside the `NamedTuple`. In principle, the `accepted_kwargs` can be directly obtained from `kwargs` keys, but I left it for consistency with the other functions.

Furthermore, I've extended the methods of the `get_filtered_kwargs`, also supporting `Val` types for `accepted_kwargs`. In this way, the filtering is performed at compile time, otherwise the type of the `NamedTuple` cannot be inferred. Thus, all the other functions supporting `accepted_kwargs` would also support `Val` types, improving performance.