### PR TITLE
Improve the update_coefficients of ScalarOperator

### DIFF
--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -194,9 +194,8 @@ function update_coefficients!(L::ScalarOperator, u, p, t; kwargs...)
     nothing
 end
 
-function update_coefficients(L::ScalarOperator, u, p, t; kwargs...)
-    update_coefficients!(L, u, p, t; kwargs...)
-    L
+function SciMLOperators.update_coefficients(L::ScalarOperator, u, p, t; kwargs...)
+    return ScalarOperator(L.update_func(L.val, u, p, t; kwargs...), L.update_func)
 end
 
 """


### PR DESCRIPTION
With this PR, I improve the out-of-place case of the `update_coefficients` function for the `ScalarOperator` type. This would fix the out-of-place differentiation using Zygote of an ODE, as shown in [this issue}(https://github.com/SciML/SciMLSensitivity.jl/issues/1139) on SciMLSensitivity.jl
