### PR TITLE
All necessary fallbacks to the interface definition

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -251,6 +251,7 @@ UniformScaling,
 Factorization, # Base
 Number}) = true
 isconstant(L::AbstractSciMLOperator) = all(isconstant, getops(L))
+isconstant(L) = false
 
 """
     isconvertible(L) -> Bool
@@ -307,6 +308,7 @@ $SIGNATURES
 Checks if `L` is a linear operator.
 """
 islinear(::AbstractSciMLOperator) = false
+islinear(L) = false
 
 islinear(::Union{# LinearAlgebra
 AbstractMatrix,


### PR DESCRIPTION
This fixes a DiffEqBase type piracy that was relied on downstream.
