### PR TITLE
mul! for out-of-place FunctionOperator

### DIFF
--- a/src/func.jl
+++ b/src/func.jl
@@ -772,7 +772,7 @@ function LinearAlgebra.mul!(w::AbstractArray, L::FunctionOperator{true}, v::Abst
     vec_output ? vec(W) : W
 end
 
-function LinearAlgebra.mul!(w::AbstractArray, L::FunctionOperator{false}, ::AbstractArray,
+function LinearAlgebra.mul!(w::AbstractArray, L::FunctionOperator{false}, v::AbstractArray,
         args...)
     _sizecheck(L, v, w)
     V, W, vec_output = _unvec(L, v, w)

--- a/src/func.jl
+++ b/src/func.jl
@@ -619,7 +619,7 @@ isconvertible(L::FunctionOperator) = L.traits.isconvertible
 isconstant(L::FunctionOperator) = L.traits.isconstant
 has_adjoint(L::FunctionOperator) = !(L.op_adjoint isa Nothing)
 has_mul(::FunctionOperator{iip}) where {iip} = true
-has_mul!(::FunctionOperator{iip}) where {iip} = iip
+has_mul!(::FunctionOperator{iip}) where {iip} = true
 has_ldiv(L::FunctionOperator{iip}) where {iip} = !(L.op_inverse isa Nothing)
 has_ldiv!(L::FunctionOperator{iip}) where {iip} = iip & !(L.op_inverse isa Nothing)
 

--- a/test/func.jl
+++ b/test/func.jl
@@ -167,7 +167,7 @@ end
 
     # Test standard operator operations (from original test)
     w = rand(N, K)
-    @test _mul(A, v) ≈ op1 * v ≈ mul!(w, op2, v)
+    @test _mul(A, v) ≈ op1 * v ≈ mul!(w, op2, v) ≈ mul!(w, op1, v) 
     w = rand(N, K)
     @test _mul(A, v) ≈ op1(v, u, p, t) ≈ op2(v, u, p, t)
     v = rand(N, K)

--- a/test/func.jl
+++ b/test/func.jl
@@ -133,7 +133,7 @@ end
     @test size(op1) == (NK, NK)
     @test has_adjoint(op1)
     @test has_mul(op1)
-    @test !has_mul!(op1)
+    @test has_mul!(op1)
     @test has_ldiv(op1)
     @test !has_ldiv!(op1)
 
@@ -248,7 +248,7 @@ end
     @test size(op1) == (N, N)
     @test has_adjoint(op1)
     @test has_mul(op1)
-    @test !has_mul!(op1)
+    @test has_mul!(op1)
     @test has_ldiv(op1)
     @test !has_ldiv!(op1)
 


### PR DESCRIPTION
mul! for out-of-place FunctionOperators was added in #275, but with a typo: a missing argument name. This PR adds the argument name and a test.

Now that `mul!` exists for oop FunctionOperators, should `has_mul!`  at https://github.com/SciML/SciMLOperators.jl/blob/41a4dc6b4424e164fb595603f849022c05823c09/src/func.jl#L622 be changed to always return true?