### PR TITLE
Fix spurious memory allocations of `AddedOperator` after regression with v1.0 release

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -620,14 +620,13 @@ end
 # Out-of-place: v is action vector, u is update vector
 function (L::AddedOperator)(v::AbstractVecOrMat, u, p, t; kwargs...)
     # We don't need to update coefficients of L, as op(v, u, p, t) will do it for each op
-    sum(op -> iszero(op) ? zero(v) : op(v, u, p, t; kwargs...), L.ops)
+    sum(op -> op(v, u, p, t; kwargs...), L.ops)
 end
 
 # In-place: w is destination, v is action vector, u is update vector
 @generated function (L::AddedOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
     # We don't need to update coefficients of L, as op(w, v, u, p, t) will do it for each op
 
-    T = L.parameters[1]
     ops_types = L.parameters[2].parameters
     N = length(ops_types)-1
 
@@ -635,7 +634,7 @@ end
         L.ops[1](w, v, u, p, t; kwargs...)
         Base.@nexprs $N i->begin
             op = L.ops[i+1]
-            op(w, v, u, p, t, one($T), one($T); kwargs...)
+            op(w, v, u, p, t, true, true; kwargs...)
         end
         w
     end
@@ -653,7 +652,7 @@ end
         L.ops[1](w, v, u, p, t, α, β; kwargs...)
         Base.@nexprs $N i->begin
             op = L.ops[i+1]
-            op(w, v, u, p, t, α, one($T); kwargs...)
+            op(w, v, u, p, t, α, true; kwargs...)
         end
         w
     end

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -616,33 +616,47 @@ end
         w
     end
 end
+
 # Out-of-place: v is action vector, u is update vector
 function (L::AddedOperator)(v::AbstractVecOrMat, u, p, t; kwargs...)
-    L = update_coefficients(L, u, p, t; kwargs...)
+    # We don't need to update coefficients of L, as op(v, u, p, t) will do it for each op
     sum(op -> iszero(op) ? zero(v) : op(v, u, p, t; kwargs...), L.ops)
 end
 
 # In-place: w is destination, v is action vector, u is update vector
-function (L::AddedOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
-    update_coefficients!(L, u, p, t; kwargs...)
-    for op in L.ops
-        if !iszero(op)
-            op(w, v, u, p, t, 1.0, 1.0; kwargs...)
+@generated function (L::AddedOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
+    # We don't need to update coefficients of L, as op(w, v, u, p, t) will do it for each op
+
+    T = L.parameters[1]
+    ops_types = L.parameters[2].parameters
+    N = length(ops_types)-1
+
+    quote
+        L.ops[1](w, v, u, p, t; kwargs...)
+        Base.@nexprs $N i->begin
+            op = L.ops[i+1]
+            op(w, v, u, p, t, one($T), one($T); kwargs...)
         end
+        w
     end
-    w
 end
 
 # In-place with scaling: w = α*(L*v) + β*w
-function (L::AddedOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
-    update_coefficients!(L, u, p, t; kwargs...)
-    lmul!(β, w)
-    for op in L.ops
-        if !iszero(op)
-            op(w, v, u, p, t, α, 1.0; kwargs...)
+@generated function (L::AddedOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
+    # We don't need to update coefficients of L, as op(w, v, u, p, t) will do it for each op
+
+    T = L.parameters[1]
+    ops_types = L.parameters[2].parameters
+    N = length(ops_types)-1
+
+    quote
+        L.ops[1](w, v, u, p, t, α, β; kwargs...)
+        Base.@nexprs $N i->begin
+            op = L.ops[i+1]
+            op(w, v, u, p, t, α, one($T); kwargs...)
         end
+        w
     end
-    w
 end
 
 """

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -201,7 +201,7 @@ function (L::MatrixOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; 
 end
 
 # In-place with scaling: w = α*(L*v) + β*w
-function (L::MatrixOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
+Base.@constprop :aggressive function (L::MatrixOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
     update_coefficients!(L, u, p, t; kwargs...)
     mul!(w, L.A, v, α, β)
 end

--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,5 +1,0 @@
-[deps]
-AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-
-[compat]
-AllocCheck = "0.2.2"

--- a/test/downstream/alloccheck.jl
+++ b/test/downstream/alloccheck.jl
@@ -1,62 +1,59 @@
-using SciMLOperators, AllocCheck, Random, SparseArrays, Test
+using SciMLOperators, Random, SparseArrays, Test
 using SciMLOperators: IdentityOperator,
                       NullOperator,
                       ScaledOperator,
                       AddedOperator
-Random.seed!(0)
-N = 8
-K = 12
-A = rand(N, N) |> MatrixOperator
-B = rand(N, N) |> MatrixOperator
-C = rand(N, N) |> MatrixOperator
-α = rand()
-β = rand()
-u = rand(N, K)       # Update vector
-v = rand(N, K)       # Action vector
-w = zeros(N, K)      # Output vector
-p = ()
-t = 0
-op = AddedOperator(A, B)
 
-# Define a function to test allocations with the new interface
-@check_allocs ignore_throw = true function apply_op!(H, w, v, u, p, t)
-    H(w, v, u, p, t)
-    return nothing
-end
+@testset "Allocations Check" begin
+    Random.seed!(0)
+    N = 8
+    K = 12
+    A = rand(N, N) |> MatrixOperator
+    B = rand(N, N) |> MatrixOperator
+    u = rand(N, K)       # Update vector
+    v = rand(N, K)       # Action vector
+    w = zeros(N, K)      # Output vector
+    p = ()
+    t = 0
+    op = AddedOperator(A, B)
 
-if VERSION >= v"1.12-beta"
-    apply_op!(op, w, v, u, p, t)
-else
-    @test_throws AllocCheckFailure apply_op!(op, w, v, u, p, t)
-end
+    function apply_op!(H, w, v, u, p, t)
+        H(w, v, u, p, t)
+        return nothing
+    end
 
-for T in (Float32, Float64, ComplexF32, ComplexF64)
-    N = 100
-    A1_sparse = MatrixOperator(sprand(T, N, N, 5 / N))
-    A2_sparse = MatrixOperator(sprand(T, N, N, 5 / N))
-    A3_sparse = MatrixOperator(sprand(T, N, N, 5 / N))
+    test_apply_noalloc(H, w, v, u, p, t) = @test (@allocations apply_op!(H, w, v, u, p, t)) == 0
 
-    A1_dense = MatrixOperator(rand(T, N, N))
-    A2_dense = MatrixOperator(rand(T, N, N))
-    A3_dense = MatrixOperator(rand(T, N, N))
+    test_apply_noalloc(op, w, v, u, p, t)
 
-    coeff1(a, u, p, t) = sin(p.ω * t)
-    coeff2(a, u, p, t) = cos(p.ω * t)
-    coeff3(a, u, p, t) = sin(p.ω * t) * cos(p.ω * t)
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        N = 100
+        A1_sparse = MatrixOperator(sprand(T, N, N, 5 / N))
+        A2_sparse = MatrixOperator(sprand(T, N, N, 5 / N))
+        A3_sparse = MatrixOperator(sprand(T, N, N, 5 / N))
 
-    c1 = ScalarOperator(rand(T), coeff1)
-    c2 = ScalarOperator(rand(T), coeff2)
-    c3 = ScalarOperator(rand(T), coeff3)
+        A1_dense = MatrixOperator(rand(T, N, N))
+        A2_dense = MatrixOperator(rand(T, N, N))
+        A3_dense = MatrixOperator(rand(T, N, N))
 
-    H_sparse = c1 * A1_sparse + c2 * A2_sparse + c3 * A3_sparse
-    H_dense = c1 * A1_dense + c2 * A2_dense + c3 * A3_dense
+        coeff1(a, u, p, t) = sin(p.ω * t)
+        coeff2(a, u, p, t) = cos(p.ω * t)
+        coeff3(a, u, p, t) = sin(p.ω * t) * cos(p.ω * t)
 
-    u = rand(T, N)
-    v = rand(T, N) 
-    w = similar(u)
-    p = (ω = 0.1,)
-    t = 0.1
+        c1 = ScalarOperator(rand(T), coeff1)
+        c2 = ScalarOperator(rand(T), coeff2)
+        c3 = ScalarOperator(rand(T), coeff3)
 
-    @test_throws AllocCheckFailure apply_op!(H_sparse, w, v, u, p, t)
-    @test_throws AllocCheckFailure apply_op!(H_dense, w, v, u, p, t)
+        H_sparse = c1 * A1_sparse + c2 * A2_sparse + c3 * A3_sparse
+        H_dense = c1 * A1_dense + c2 * A2_dense + c3 * A3_dense
+
+        u = rand(T, N)
+        v = rand(T, N) 
+        w = similar(u)
+        p = (ω = 0.1,)
+        t = 0.1
+
+        test_apply_noalloc(H_sparse, w, v, u, p, t)
+        test_apply_noalloc(H_dense, w, v, u, p, t)
+    end
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This fixes #247 after regression with v1.0 release.
