### PR TITLE
Improve IdentityOperator and ScaledOperator actions

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -77,16 +77,14 @@ function (ii::IdentityOperator)(v::AbstractVecOrMat, u, p, t; kwargs...)
 end
 
 # In-place: w is destination, v is action vector, u is update vector
-function (ii::IdentityOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
+@inline function (ii::IdentityOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
     @assert size(v, 1) == ii.len
-    update_coefficients!(ii, u, p, t; kwargs...)
     copy!(w, v)
 end
 
 # In-place with scaling: w = α*(ii*v) + β*w
-function (ii::IdentityOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
+@inline function (ii::IdentityOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
     @assert size(v, 1) == ii.len
-    update_coefficients!(ii, u, p, t; kwargs...)
     mul!(w, I, v, α, β)
 end
 
@@ -388,29 +386,17 @@ function (L::ScaledOperator)(v::AbstractVecOrMat, u, p, t; kwargs...)
 end
 
 # In-place: w is destination, v is action vector, u is update vector
-function (L::ScaledOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
-    update_coefficients!(L, u, p, t; kwargs...)
-    if iszero(L.λ)
-        lmul!(false, w)
-        return w
-    else
-        a = convert(Number, L.λ)
-        mul!(w, L.L, v, a, false)
-        return w
-    end
+@inline function (L::ScaledOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
+    update_coefficients!(L.λ, u, p, t; kwargs...)
+    a = convert(Number, L.λ)
+    return L.L(w, v, u, p, t, a, false; kwargs...)
 end
 
 # In-place with scaling: w = α*(L*v) + β*w
-function (L::ScaledOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
-    update_coefficients!(L, u, p, t; kwargs...)
-    if iszero(L.λ)
-        lmul!(β, w)
-        return w
-    else
-        a = convert(Number, L.λ * α)
-        mul!(w, L.L, v, a, β)
-        return w
-    end
+@inline function (L::ScaledOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...)
+    update_coefficients!(L.λ, u, p, t; kwargs...)
+    a = convert(Number, L.λ * α)
+    return L.L(w, v, u, p, t, a, β; kwargs...)
 end
 
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I slightly improved the `IdentityOperator` and `ScaledOperator` action. 

More specifically, I removed the `update_coefficients` in the `IdentityOperator`, as it is constant by construction.

I have also simplified the action of a `ScaledOpertator`. The previous implementation was directly using `mul!`, which I think it not always the case, as `ScaledOperator` may contain a more complex operator in `L.L`. So, I first update the coefficients of `L.λ`, and then directly apply the operator action `L.L(w, v, u, p, t)`.

After merging this PR (if accepted), could we release a new version? It is needed to add support in QuantumToolbox.jl of the new v1 version.