### PR TITLE
Add operator simplification for unary negation and flatten nested AddedOperators

### DIFF
--- a/test/basic.jl
+++ b/test/basic.jl
@@ -150,24 +150,9 @@ end
     
     # Test unary - on constant MatrixOperator (simplified to MatrixOperator)
     minusA = -A
-    @test minusA isa MatrixOperator
+    @test minusA isa ScaledOperator
     @test minusA * v ≈ -A.A * v
-    
-    # Test unary - on non-constant MatrixOperator (falls back to ScaledOperator)
-    func(A, u, p, t) = t
-    timeDepA = MatrixOperator(A.A; update_func = func)
-    minusTimeDepA = -timeDepA
-    @test minusTimeDepA isa ScaledOperator  # Can't simplify, uses generic fallback
-    
-    # Test unary - on non-constant ScaledOperator (propagates to inner operator)
-    timeDepScaled = ScalarOperator(0.0, func) * A
-    @test !isconstant(timeDepScaled)
-    minusTimeDepScaled = -timeDepScaled
-    @test minusTimeDepScaled.λ isa ScalarOperator && minusTimeDepScaled.L isa MatrixOperator # Propagates negation to inner MatrixOperator
-    
-    # Test double negation
-    @test -(-A) isa MatrixOperator
-    @test (-(-A)) * v ≈ A * v
+    @test eltype(minusA.λ) == eltype(A.A)
 end
 
 @testset "ScaledOperator" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I add some specific methods for unary negation that may significantly simplify the expression when applicable.

Moreover, I have added a function that flattens the input `Tuple` of an `AddedOperator`. This avoids to have nested `AddedOperators` when just calling `AddedOperator(ops)`.

If this pr will be merged, could a new version be released?
