### PR TITLE
Remove uses of undefined `_vec`

### DIFF
--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -139,13 +139,31 @@ function Base.:\(W::WOperator, x::Number)
     end
 end
 
-function LinearAlgebra.mul!(Y::AbstractVecOrMat, W::WOperator, B::AbstractVecOrMat)
+function LinearAlgebra.mul!(Y::AbstractVector, W::WOperator, B::AbstractVector)
     # Compute mass_matrix * B
     if isa(W.mass_matrix, UniformScaling)
         a = -W.mass_matrix.λ / W.gamma
         @. Y=a*B
     else
-        mul!(_vec(Y), W.mass_matrix, vec(B))
+        mul!(Y, W.mass_matrix, B)
+        lmul!(-inv(W.gamma), Y)
+    end
+    # Compute J * B and add
+    if isnothing(W.jacvec)
+        mul!(W._func_cache, W.J, B)
+    else
+        mul!(W._func_cache, W.jacvec, B)
+    end
+    Y .+= W._func_cache
+end
+
+function LinearAlgebra.mul!(Y::AbstractArray, W::WOperator, B::AbstractArray)
+    # Compute mass_matrix * B
+    if isa(W.mass_matrix, UniformScaling)
+        a = -W.mass_matrix.λ / W.gamma
+        @. Y=a*B
+    else
+        mul!(vec(Y), W.mass_matrix, vec(B))
         lmul!(-inv(W.gamma), Y)
     end
     # Compute J * B and add


### PR DESCRIPTION
Because the args are AbstractVecOrMat this is equivalent to `vec` anyway.