### PR TITLE
Add dtgamma deprecation path in WOperator

### DIFF
--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -94,13 +94,24 @@ Base.eltype(W::WOperator) = eltype(W.J)
 
 # In WOperator update_coefficients!, accept both missing u/p/t and missing gamma and don't update them in that case.
 # This helps support partial updating logic used with Newton solvers.
+# Accept both `gamma` and deprecated `dtgamma` kwargs for backwards compatibility.
 function update_coefficients!(
         W::WOperator,
         u = nothing,
         p = nothing,
         t = nothing;
-        gamma = nothing
+        gamma = nothing,
+        dtgamma = nothing
     )
+    if dtgamma !== nothing
+        Base.depwarn(
+            "keyword argument `dtgamma` is deprecated, use `gamma` instead",
+            :update_coefficients!
+        )
+        if gamma === nothing
+            gamma = dtgamma
+        end
+    end
     if (u !== nothing) && (p !== nothing) && (t !== nothing)
         update_coefficients!(W.J, u, p, t)
         update_coefficients!(W.mass_matrix, u, p, t)

--- a/test/WOperator.jl
+++ b/test/WOperator.jl
@@ -22,4 +22,9 @@ Random.seed!(0)
     # Update and convert again
     update_coefficients!(W_scalar; gamma = 0.25)
     @test convert(Number, W_scalar) ≈ 2.0 - 1.0 / 0.25
+
+    # Test deprecated dtgamma kwarg on WOperator
+    W_scalar2 = WOperator{false}(I, 0.5, ScalarOperator(2.0), 1.0)
+    @test_deprecated update_coefficients!(W_scalar2; dtgamma = 0.25)
+    @test convert(Number, W_scalar2) ≈ 2.0 - 1.0 / 0.25
 end


### PR DESCRIPTION
## Summary
- Adds backwards compatibility for the deprecated `dtgamma` keyword argument in `WOperator`'s `update_coefficients!`
- Old code in registered `OrdinaryDiffEqDifferentiation` passes `dtgamma` to the WOperator, but the new SciMLOperators WOperator only accepts `gamma`
- This accepts both kwargs with a deprecation warning for `dtgamma`, allowing the transition period where registered packages still use the old kwarg name

## Test plan
- [x] Added test using `@test_deprecated` for the `dtgamma` kwarg
- [x] All existing tests pass (728 pass, 2 pre-existing broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)