### PR TITLE
Add dtgamma->gamma remapping in FilterKwargs for compound operators

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,6 +62,16 @@ function get_filtered_kwargs(
         ::Val{accepted_kwargs}
     ) where {accepted_kwargs}
     kwargs_nt = NamedTuple(kwargs)
+    # Remap deprecated dtgamma -> gamma when gamma is accepted but dtgamma is not
+    if :gamma in accepted_kwargs && !(:dtgamma in accepted_kwargs) &&
+       haskey(kwargs_nt, :dtgamma) && !haskey(kwargs_nt, :gamma)
+        Base.depwarn(
+            "keyword argument `dtgamma` is deprecated, use `gamma` instead",
+            :update_coefficients!)
+        kwargs_nt = merge(
+            Base.structdiff(kwargs_nt, NamedTuple{(:dtgamma,)}),
+            (gamma = kwargs_nt.dtgamma,))
+    end
     # Only extract keys that exist in kwargs_nt to avoid errors
     filtered_keys = filter(k -> haskey(kwargs_nt, k), accepted_kwargs)
     return NamedTuple{filtered_keys}(kwargs_nt)


### PR DESCRIPTION
## Summary
- When old code passes `dtgamma` kwarg through compound operators to `ScalarOperator`s with `accepted_kwargs=Val((:gamma,))`, the `FilterKwargs` mechanism now transparently remaps `dtgamma` to `gamma` with a deprecation warning
- This only triggers when `gamma` is in `accepted_kwargs` but `dtgamma` is not, preserving backwards compatibility for operators that explicitly accept `dtgamma`
- Fixes the InterfaceII lts CI failure in OrdinaryDiffEq.jl PR #3017 where registered `OrdinaryDiffEqDifferentiation` passes `dtgamma` to custom W prototypes built from `ScalarOperator`s

## Context
PR #347 added the `dtgamma` deprecation to `WOperator.update_coefficients!`, but the InterfaceII lts test uses a custom W prototype (compound operator, not `WOperator`) where `dtgamma` flows through to `ScalarOperator`s via `FilterKwargs`. This PR fixes that path.

## Test plan
- [x] All existing tests pass (728 pass, 2 pre-existing broken)
- [x] Manually verified: `ScalarOperator` with `accepted_kwargs=Val((:gamma,))` correctly receives `gamma` when `dtgamma` is passed
- [x] Manually verified: `ScalarOperator` with `accepted_kwargs=Val((:dtgamma,))` still receives `dtgamma` directly (no remapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)