### PR TITLE
Update caching fns and * to use generated

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -913,7 +913,7 @@ end
         push!(exprs, :(v = L.ops[$i] * v))
     end
 
-    quote
+    return quote
         $(exprs...)
         v
     end
@@ -927,25 +927,27 @@ end
     exprs = [:(cache = (zero(v),))]
 
     for i in N:-1:2
-        push!(exprs, quote
-            op = L.ops[$i]
-            M = size(op, 1)
-            sz = v isa AbstractMatrix ? (M, K) : (M,)
+        push!(
+            exprs, quote
+                op = L.ops[$i]
+                M = size(op, 1)
+                sz = v isa AbstractMatrix ? (M, K) : (M,)
 
-            T = if op isa FunctionOperator
-                # FunctionOperator isn't guaranteed to play by the rules of
-                # `promote_type`. For example, an irFFT is a complex operation
-                # that accepts complex vector and returns ones.
-                output_eltype(op)
-            else
-                promote_type(eltype.((op, cache[1]))...)
+                T = if op isa FunctionOperator
+                    # FunctionOperator isn't guaranteed to play by the rules of
+                    # `promote_type`. For example, an irFFT is a complex operation
+                    # that accepts complex vector and returns ones.
+                    output_eltype(op)
+                else
+                    promote_type(eltype.((op, cache[1]))...)
+                end
+
+                cache = (similar(v, T, sz), cache...)
             end
-
-            cache = (similar(v, T, sz), cache...)
-        end)
+        )
     end
 
-    quote
+    return quote
         K = size(v, 2)
         $(exprs...)
         @reset L.cache = cache
@@ -962,7 +964,7 @@ end
         push!(exprs, :(ops = (cache_operator(L.ops[$i], L.cache[$i]), ops...)))
     end
 
-    quote
+    return quote
         if isnothing(L.cache)
             L = cache_self(L, v)
         end

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -900,51 +900,77 @@ function Base.:\(L::ComposedOperator, v::AbstractVecOrMat)
     return v
 end
 
-function Base.:*(L::ComposedOperator, v::AbstractVecOrMat)
-    for op in reverse(L.ops)
-        v = op * v
+@generated function Base.:*(L::ComposedOperator, v::AbstractVecOrMat)
+    N = length(L.parameters[2].parameters)  # Number of operators
+
+    # Generate the composition in reverse order
+    # v = L.ops[N] * v
+    # v = L.ops[N-1] * v
+    # ...
+    # v = L.ops[1] * v
+    exprs = []
+    for i in N:-1:1
+        push!(exprs, :(v = L.ops[$i] * v))
     end
 
-    return v
+    quote
+        $(exprs...)
+        v
+    end
 end
 
-function cache_self(L::ComposedOperator, v::AbstractVecOrMat)
-    K = size(v, 2)
-    cache = (zero(v),)
+@generated function cache_self(L::ComposedOperator, v::AbstractVecOrMat)
+    N = length(L.parameters[2].parameters)  # Number of operators
 
-    for i in reverse(2:length(L.ops))
-        op = L.ops[i]
+    # Build cache from the end backwards (starting from zero(v))
+    # For each operator from N down to 2, create a cache entry
+    exprs = [:(cache = (zero(v),))]
 
-        M = size(op, 1)
-        sz = v isa AbstractMatrix ? (M, K) : (M,)
+    for i in N:-1:2
+        push!(exprs, quote
+            op = L.ops[$i]
+            M = size(op, 1)
+            sz = v isa AbstractMatrix ? (M, K) : (M,)
 
-        T = if op isa FunctionOperator #
-            # FunctionOperator isn't guaranteed to play by the rules of
-            # `promote_type`. For example, an irFFT is a complex operation
-            # that accepts complex vector and returns  ones.
-            output_eltype(op)
-        else
-            promote_type(eltype.((op, cache[1]))...)
+            T = if op isa FunctionOperator
+                # FunctionOperator isn't guaranteed to play by the rules of
+                # `promote_type`. For example, an irFFT is a complex operation
+                # that accepts complex vector and returns ones.
+                output_eltype(op)
+            else
+                promote_type(eltype.((op, cache[1]))...)
+            end
+
+            cache = (similar(v, T, sz), cache...)
+        end)
+    end
+
+    quote
+        K = size(v, 2)
+        $(exprs...)
+        @reset L.cache = cache
+        L
+    end
+end
+
+@generated function cache_internals(L::ComposedOperator, v::AbstractVecOrMat)
+    N = length(L.parameters[2].parameters)  # Number of operators
+
+    # Cache each operator with its corresponding cache entry
+    exprs = []
+    for i in N:-1:1
+        push!(exprs, :(ops = (cache_operator(L.ops[$i], L.cache[$i]), ops...)))
+    end
+
+    quote
+        if isnothing(L.cache)
+            L = cache_self(L, v)
         end
 
-        cache = (similar(v, T, sz), cache...)
+        ops = ()
+        $(exprs...)
+        @reset L.ops = ops
     end
-
-    @reset L.cache = cache
-    return L
-end
-
-function cache_internals(L::ComposedOperator, v::AbstractVecOrMat)
-    if isnothing(L.cache)
-        L = cache_self(L, v)
-    end
-
-    ops = ()
-    for i in reverse(1:length(L.ops))
-        ops = (cache_operator(L.ops[i], L.cache[i]), ops...)
-    end
-
-    return @reset L.ops = ops
 end
 
 @generated function LinearAlgebra.mul!(w::AbstractVecOrMat, L::ComposedOperator, v::AbstractVecOrMat)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

The PR slightly improves the performance of using Operators in OrdinaryDiffEq, which will be beneficial in developing AMF-type schemes.

MWE:

```julia

using LinearAlgebra, OrdinaryDiffEqSDIRK, SciMLOperators

function chain!(du,u,p,t)
    a = 10.0
    du[1] = -a*u[1]
    for i in 2:length(u)
        du[i] = a*(u[i-1]-u[i])
    end
end
function jac_chain!(J,u,p,t)
    a = 10.0; fill!(J,0.0)
    for i in 2:length(u)
        J[i,i] = -a
        if i>1; J[i,i-1] = a; end
    end
end

N=1000
u0=ones(N)
tspan = (0.0, 2.0)

J = zeros(N, N)

jac_chain!(J, u0, nothing, 0.0)


I_N = Diagonal(ones(N))


J1_op = MatrixOperator(UpperTriangular(J - Diagonal(J)))
J2_op = MatrixOperator(LowerTriangular(J))
J_op = J1_op + J2_op

J_op = cache_operator(J_op, zeros(N^2))


Ju = UpperTriangular(J - Diagonal(J))

W1_op = MatrixOperator(
    I_N - Ju;
    update_func! = (M, u, p, t;
    gamma = 1.0
    ) ->(@. M = I_N - gamma * Ju),
    accepted_kwargs = Val((:gamma,)),
)

Jl = LowerTriangular(J)

W2_op = MatrixOperator(
    I_N - Jl;
    update_func! = (M, u, p, t; gamma = 1.0) ->
        (@. M = I_N - gamma * Jl),
    accepted_kwargs = Val((:gamma,)),
)

transform_op = ScalarOperator(
    0.0;
    update_func = (old_op, u, p, t; gamma = 1.0) ->
        true ? inv(gamma) : one(gamma),
    accepted_kwargs = Val((:gamma, )),
)

W_prototype = -(W1_op * W2_op) * transform_op

W_prototype = cache_operator(W_prototype, zeros(N))

func = ODEFunction{true, SciMLBase.FullSpecialize}(chain!; jac_prototype = MatrixOperator(J), jac = jac_chain!, W_prototype, sparsity = convert(AbstractMatrix, J_op))
prob = ODEProblem(func, u0, tspan)

@time sol = solve(prob, KenCarp4());
```

```julia
Before:

julia> @benchmark sol = solve($prob, KenCarp4())
BenchmarkTools.Trial: 2 samples with 1 evaluation per sample.
 Range (min … max):  4.599 s …   4.616 s  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.607 s              ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.607 s ± 12.247 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                       █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  4.6 s          Histogram: frequency by time        4.62 s <

 Memory estimate: 6.11 MiB, allocs estimate: 17824.

After:

 julia> @benchmark solve($prob, KenCarp4())
BenchmarkTools.Trial: 2 samples with 1 evaluation per sample.
 Range (min … max):  3.619 s …   3.670 s  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.644 s              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.644 s ± 36.291 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                       █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  3.62 s         Histogram: frequency by time        3.67 s <

 Memory estimate: 6.11 MiB, allocs estimate: 17824.
```