### PR TITLE
Simplify tensor structure and operations in the presence of IdentiyOp…

### DIFF
--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -97,10 +97,14 @@ function TensorProductOperator(ii1::IdentityOperator, ii2::IdentityOperator)
     return IdentityOperator(ii1.len * ii2.len)
 end
 function TensorProductOperator(ii::IdentityOperator, op::TensorProductOperator)
-    return TensorProductOperator(TensorProductOperator(ii, op.ops[1]), op.ops[2])
+    left = TensorProductOperator(ii, op.ops[1])
+    # We call the main method to avoid recursion with the method below
+    return TensorProductOperator((left, op.ops[2]), nothing)
 end
 function TensorProductOperator(op::TensorProductOperator, ii::IdentityOperator)
-    return TensorProductOperator(op.ops[1], TensorProductOperator(op.ops[2], ii))
+    right = TensorProductOperator(op.ops[2], ii)
+    # We call the main method to avoid recursion with the method above
+    return TensorProductOperator((op.ops[1], right), nothing)
 end
 
 """
@@ -260,7 +264,7 @@ function cache_internals(L::TensorProductOperator, v::AbstractVecOrMat)
     k = size(v, 2)
 
     vinner = reshape(v, (ni, no * k))
-    vouter = reshape(v, (no, mi * k))
+    vouter = reshape(@view(v[1:(no * mi * k)]), (no, mi * k))
 
     @reset L.ops[2] = cache_operator(inner, vinner)
     @reset L.ops[1] = cache_operator(outer, vouter)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -225,13 +225,15 @@ function cache_self(L::TensorProductOperator, v::AbstractVecOrMat)
     mo, no = size(outer)
     k = size(v, 2)
 
+    is_outer_identity = outer isa IdentityOperator
+
     # 3 arg mul!
-    c1 = lmul!(false, similar(v, (mi, no * k))) # c1 = inner * v
-    c2 = lmul!(false, similar(v, (no, mi, k))) # permute (2, 1, 3)
-    c3 = lmul!(false, similar(v, (mo, mi * k))) # c3 = outer * c2
+    c1 = is_outer_identity ? nothing : lmul!(false, similar(v, (mi, no * k))) # c1 = inner * v
+    c2 = is_outer_identity ? nothing : lmul!(false, similar(v, (no, mi, k))) # permute (2, 1, 3)
+    c3 = is_outer_identity ? nothing : lmul!(false, similar(v, (mo, mi * k))) # c3 = outer * c2
 
     # 5 arg mul!
-    c4 = lmul!(false, similar(v, (mo * mi, k))) # cache v in 5 arg mul!
+    c4 = is_outer_identity ? nothing : lmul!(false, similar(v, (mo * mi, k))) # cache v in 5 arg mul!
 
     # 3 arg ldiv!
     if reduce(&, issquare.(L.ops))
@@ -258,7 +260,7 @@ function cache_internals(L::TensorProductOperator, v::AbstractVecOrMat)
     k = size(v, 2)
 
     vinner = reshape(v, (ni, no * k))
-    vouter = reshape(L.cache[2], (no, mi * k))
+    vouter = reshape(v, (no, mi * k))
 
     @reset L.ops[2] = cache_operator(inner, vinner)
     @reset L.ops[1] = cache_operator(outer, vouter)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -96,6 +96,12 @@ TensorProductOperator(op::AbstractMatrix) = MatrixOperator(op)
 function TensorProductOperator(ii1::IdentityOperator, ii2::IdentityOperator)
     return IdentityOperator(ii1.len * ii2.len)
 end
+function TensorProductOperator(ii::IdentityOperator, op::TensorProductOperator)
+    return TensorProductOperator(TensorProductOperator(ii, op.ops[1]), op.ops[2])
+end
+function TensorProductOperator(op::TensorProductOperator, ii::IdentityOperator)
+    return TensorProductOperator(op.ops[1], TensorProductOperator(op.ops[2], ii))
+end
 
 """
 $SIGNATURES
@@ -269,17 +275,19 @@ function LinearAlgebra.mul!(
 
     outer, inner = L.ops
 
-    _, ni = size(inner)
-    _, no = size(outer)
+    mi, ni = size(inner)
+    mo, no = size(outer)
     k = size(v, 2)
 
-    C1, C2, C3 = L.cache[1:3]
+    C1 = first(L.cache)
     U = reshape(v, (ni, no * k))
 
     #=
         v .= kron(B, A) * v
         V .= A * U * B'
     =#
+
+    outer isa IdentityOperator && return mul!(reshape(w, (mi, no * k)), inner, U)
 
     # C .= A * U
     mul!(C1, inner, U)
@@ -313,6 +321,8 @@ function LinearAlgebra.mul!(
         v .= α * kron(B, A) * u + β * v
         V .= α * (A * U * B') + β * v
     """
+
+    outer isa IdentityOperator && return mul!(reshape(w, (mi, no * k)), inner, U, α, β)
 
     # C .= A * U
     mul!(C1, inner, U)
@@ -424,10 +434,7 @@ function outer_mul!(w::AbstractVecOrMat, L::TensorProductOperator, v::AbstractVe
 
     C1 = first(L.cache)
 
-    if outer isa IdentityOperator
-        copyto!(w, C1)
-        return w
-    elseif outer isa ScaledOperator
+    if outer isa ScaledOperator
         outer_mul!(w, outer.L, v)
         lmul!(outer.λ, w)
         return w
@@ -467,11 +474,7 @@ function outer_mul!(
     m, _ = size(L)
     k = size(v, 2)
 
-    if outer isa IdentityOperator
-        v = reshape(v, (m, k))
-        axpby!(α, v, β, w)
-        return w
-    elseif outer isa ScaledOperator
+    if outer isa ScaledOperator
         a = convert(Number, α * outer.λ)
         outer_mul!(w, outer.L, v, a, β)
         return w

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -654,4 +654,72 @@ end
         w3 = zeros(N3, K)    # Output vector
         @test_broken ldiv!(w3, opABC_F, v3) ≈ ABC \ v3 # errors
     end
+
+    @testset "Simplified Structure with IdentityOperator" begin
+        Id1 = IdentityOperator(m1)
+        Id2 = IdentityOperator(m2)
+        Id3 = IdentityOperator(m3)
+        A1 = MatrixOperator(rand(n1, n1))
+        A2 = MatrixOperator(rand(n2, n2))
+
+        op1 = kron(A1, Id1, Id2, Id3)
+        op2 = kron(Id1, A1, Id2, Id3)
+        op3 = kron(Id1, Id2, A1, Id3)
+        op4 = kron(Id1, Id2, Id3, A1)
+
+        op5 = kron(A1, A2, Id1, Id2)
+        op6 = kron(Id1, A1, A2, Id2)
+        op7 = kron(Id1, Id2, A1, A2)
+
+        # Test the structure of the resulting operators
+        # The nesting depth structure should be 2 at most
+        @test op1.ops[1] isa MatrixOperator
+        @test op1.ops[2] isa IdentityOperator
+
+        @test op2.ops[1] isa TensorProductOperator
+        @test op2.ops[2] isa IdentityOperator
+        @test op2.ops[1].ops[1] isa IdentityOperator
+        @test op2.ops[1].ops[2] isa MatrixOperator
+
+        @test op3.ops[1] isa TensorProductOperator
+        @test op3.ops[2] isa IdentityOperator
+        @test op3.ops[1].ops[1] isa IdentityOperator
+        @test op3.ops[1].ops[2] isa MatrixOperator
+
+        @test op4.ops[1] isa IdentityOperator
+        @test op4.ops[2] isa MatrixOperator
+
+        @test op5.ops[1] isa MatrixOperator
+        @test op5.ops[2] isa TensorProductOperator
+        @test op5.ops[2].ops[1] isa MatrixOperator
+        @test op5.ops[2].ops[2] isa IdentityOperator
+
+        @test op6.ops[1] isa TensorProductOperator
+        @test op6.ops[2] isa TensorProductOperator
+        @test op6.ops[1].ops[1] isa IdentityOperator
+        @test op6.ops[1].ops[2] isa MatrixOperator
+        @test op6.ops[2].ops[1] isa MatrixOperator
+        @test op6.ops[2].ops[2] isa IdentityOperator
+
+        @test op7.ops[1] isa TensorProductOperator
+        @test op7.ops[2] isa MatrixOperator
+        @test op7.ops[1].ops[1] isa IdentityOperator
+        @test op7.ops[1].ops[2] isa MatrixOperator
+
+        @test convert(AbstractMatrix, op1) ≈ kron(convert(AbstractMatrix, A1), I(m1 * m2 * m3))
+        @test convert(AbstractMatrix, op2) ≈ kron(I(m1), convert(AbstractMatrix, A1), I(m2 * m3))
+        @test convert(AbstractMatrix, op3) ≈ kron(I(m1 * m2), convert(AbstractMatrix, A1), I(m3))
+        @test convert(AbstractMatrix, op4) ≈ kron(I(m1 * m2 * m3), convert(AbstractMatrix, A1))
+
+        @test convert(AbstractMatrix, op5) ≈ kron(
+            convert(AbstractMatrix, A1), convert(AbstractMatrix, A2), I(m1 * m2)
+        )
+        @test convert(AbstractMatrix, op6) ≈ kron(
+            I(m1), convert(AbstractMatrix, A1), convert(AbstractMatrix, A2), I(m2)
+        )
+        @test convert(AbstractMatrix, op7) ≈ kron(
+            I(m1 * m2), convert(AbstractMatrix, A1), convert(AbstractMatrix, A2)
+        )
+
+    end
 end


### PR DESCRIPTION
This PR simplifies the structure of a `TensorProductOperator` in presence of `IdentityOperator`. This is particularly useful when expressing operators of the form

$$
I \otimes \dots \otimes I \otimes O_i \otimes I \otimes \dots \otimes O_j \otimes I \otimes \dots \otimes I
$$

It also avoid to allocate some buffer cache arrays when the outer operator is the Identity, because the equations simplifies a lot.