### PR TITLE
Support rectangular NullOperator

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -128,31 +128,37 @@ $(TYPEDEF)
 Operator representing the null function `n(v) = 0 * v`
 """
 struct NullOperator <: AbstractSciMLOperator{Bool}
-    len::Int
+    M::Int
+    N::Int
 end
 
 # constructors
+NullOperator(N::Integer) = NullOperator(N, N)
+
 function Base.zero(L::AbstractSciMLOperator)
-    @assert issquare(L)
-    N = size(L, 1)
-    return NullOperator(N)
+    return NullOperator(size(L)...)
 end
 
-Base.convert(::Type{AbstractMatrix}, nn::NullOperator) = Diagonal(zeros(Bool, nn.len))
+function Base.convert(::Type{AbstractMatrix}, nn::NullOperator)
+    return nn.M == nn.N ? Diagonal(zeros(Bool, nn.N)) : zeros(Bool, size(nn))
+end
 has_concretization(::NullOperator) = true
 
 # Copy method to avoid aliasing - NullOperator has no mutable fields, can return self
 Base.copy(L::NullOperator) = L
 
 # traits
-Base.show(io::IO, nn::NullOperator) = print(io, "NullOperator($(nn.len))")
-Base.size(nn::NullOperator) = (nn.len, nn.len)
-Base.adjoint(A::NullOperator) = A
-Base.transpose(A::NullOperator) = A
+function Base.show(io::IO, nn::NullOperator)
+    return nn.M == nn.N ? print(io, "NullOperator($(nn.M))") :
+        print(io, "NullOperator($(nn.M), $(nn.N))")
+end
+Base.size(nn::NullOperator) = (nn.M, nn.N)
+Base.adjoint(A::NullOperator) = NullOperator(A.N, A.M)
+Base.transpose(A::NullOperator) = NullOperator(A.N, A.M)
 Base.conj(A::NullOperator) = A
 LinearAlgebra.opnorm(::NullOperator, p::Real = 2) = false
 for pred in (:issymmetric, :ishermitian)
-    @eval LinearAlgebra.$pred(::NullOperator) = true
+    @eval LinearAlgebra.$pred(nn::NullOperator) = issquare(nn)
 end
 LinearAlgebra.isposdef(::NullOperator) = false
 
@@ -164,10 +170,17 @@ has_adjoint(::NullOperator) = true
 has_mul!(::NullOperator) = true
 
 # operator application
-Base.:*(nn::NullOperator, v::AbstractVecOrMat) = (@assert size(v, 1) == nn.len; zero(v))
+function _null_output(nn::NullOperator, v::AbstractVecOrMat)
+    @assert size(v, 1) == nn.N
+    nn.M == nn.N && return zero(v)
+    return v isa AbstractMatrix ? zeros(eltype(v), nn.M, size(v, 2)) : zeros(eltype(v), nn.M)
+end
+
+Base.:*(nn::NullOperator, v::AbstractVecOrMat) = _null_output(nn, v)
 
 function LinearAlgebra.mul!(w::AbstractVecOrMat, nn::NullOperator, v::AbstractVecOrMat)
-    @assert size(v, 1) == size(w, 1) == nn.len
+    @assert size(v, 1) == nn.N
+    @assert size(w, 1) == nn.M
     return lmul!(false, w)
 end
 
@@ -178,19 +191,20 @@ function LinearAlgebra.mul!(
         α,
         β
     )
-    @assert size(v, 1) == size(w, 1) == nn.len
+    @assert size(v, 1) == nn.N
+    @assert size(w, 1) == nn.M
     return lmul!(β, w)
 end
 
 # Out-of-place: v is action vector, u is update vector
 function (nn::NullOperator)(v::AbstractVecOrMat, u, p, t; kwargs...)
-    @assert size(v, 1) == nn.len
-    return zero(v)
+    return _null_output(nn, v)
 end
 
 # In-place: w is destination, v is action vector, u is update vector
 function (nn::NullOperator)(w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...)
-    @assert size(v, 1) == nn.len
+    @assert size(v, 1) == nn.N
+    @assert size(w, 1) == nn.M
     lmul!(false, w)
     return w
 end
@@ -199,7 +213,8 @@ end
 function (nn::NullOperator)(
         w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...
     )
-    @assert size(v, 1) == nn.len
+    @assert size(v, 1) == nn.N
+    @assert size(w, 1) == nn.M
     lmul!(β, w)
     return w
 end
@@ -207,25 +222,25 @@ end
 # operator fusion, composition
 for op in (:*, :∘)
     @eval function Base.$op(nn::NullOperator, A::AbstractSciMLOperator)
-        @assert size(A, 1) == nn.len
-        return NullOperator(nn.len)
+        @assert size(A, 1) == nn.N
+        return NullOperator(nn.M, size(A, 2))
     end
 
     @eval function Base.$op(A::AbstractSciMLOperator, nn::NullOperator)
-        @assert size(A, 2) == nn.len
-        return NullOperator(nn.len)
+        @assert size(A, 2) == nn.M
+        return NullOperator(size(A, 1), nn.N)
     end
 end
 
 # operator addition, subtraction with NullOperator returns operator itself
 for op in (:+, :-)
     @eval function Base.$op(nn::NullOperator, A::AbstractSciMLOperator)
-        @assert size(A) == (nn.len, nn.len)
+        @assert size(A) == size(nn)
         return A
     end
 
     @eval function Base.$op(A::AbstractSciMLOperator, nn::NullOperator)
-        @assert size(A) == (nn.len, nn.len)
+        @assert size(A) == size(nn)
         return A
     end
 end
@@ -790,13 +805,13 @@ for op in (:*, :∘)
 
     # null operator
     @eval function Base.$op(nn::NullOperator, A::ComposedOperator)
-        @assert size(A, 1) == nn.len
-        return zero(A)
+        @assert size(A, 1) == nn.N
+        return NullOperator(nn.M, size(A, 2))
     end
 
     @eval function Base.$op(A::ComposedOperator, nn::NullOperator)
-        @assert size(A, 2) == nn.len
-        return zero(A)
+        @assert size(A, 2) == nn.M
+        return NullOperator(size(A, 1), nn.N)
     end
 
     # scalar operator

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -82,6 +82,8 @@ end
 
 @testset "NullOperator" begin
     A = rand(N, N) |> MatrixOperator
+    B = rand(N + 3, N + 2) |> MatrixOperator
+    C = rand(N, N + 3) |> MatrixOperator
     u = rand(N, K)
     v = rand(N, K)
     w = zeros(N, K)
@@ -104,6 +106,7 @@ end
     @test iscached(Z)
     @test size(Z) == (N, N)
     @test Z' isa NullOperator
+    @test size(Z') == (N, N)
 
     @test Z * u ≈ zero(u)
 
@@ -139,6 +142,40 @@ end
         @test op(Z, A) isa MatrixOperator
         @test op(A, Z) isa MatrixOperator
     end
+
+    Zrect = NullOperator(N + 2, N)
+    urect = rand(N, K)
+    wrect = zeros(N + 2, K)
+
+    @test !issquare(Zrect)
+    @test !issymmetric(Zrect)
+    @test !ishermitian(Zrect)
+    @test size(Zrect) == (N + 2, N)
+    @test convert(AbstractMatrix, Zrect) == zeros(Bool, size(Zrect))
+    @test size(Zrect') == (N, N + 2)
+    @test size(transpose(Zrect)) == (N, N + 2)
+
+    @test Zrect * urect ≈ zero(wrect)
+    @test Zrect(urect, urect, p, t) ≈ zero(wrect)
+
+    copy!(wrect, ones(N + 2, K))
+    Zrect(wrect, urect, urect, p, t)
+    @test wrect ≈ zero(wrect)
+
+    copy!(wrect, rand(N + 2, K))
+    orig_wrect = copy(wrect)
+    Zrect(wrect, urect, urect, p, t, α, β)
+    @test wrect ≈ β * orig_wrect
+
+    @test mul!(wrect, Zrect, urect) ≈ zero(wrect)
+    copy!(wrect, rand(N + 2, K))
+    orig_wrect = copy(wrect)
+    @test mul!(wrect, Zrect, urect, α, β) ≈ β * orig_wrect
+
+    @test size(Zrect * C) == (N + 2, N + 3)
+    @test size(B * Zrect) == (N + 3, N)
+    @test size(Zrect ∘ C) == (N + 2, N + 3)
+    @test size(B ∘ Zrect) == (N + 3, N)
 end
 
 @testset "Unary +/-" begin


### PR DESCRIPTION
Closes #70.

## Summary
This extends `NullOperator` to support nonsquare operator sizes while preserving the existing `NullOperator(N)` constructor for square operators.

## Changes
- Add `NullOperator(M, N)` for rectangular zero operators.
- Preserve square display and conversion behavior for `NullOperator(N)`.
- Update `size`, `adjoint`, `transpose`, application, `mul!`, and composition rules to respect rectangular dimensions.
- Make `zero(L::AbstractSciMLOperator)` return a shape-matching `NullOperator`.
- Add regression tests for rectangular sizing, conversion, predicates, application, in-place multiplication, scaled multiplication, and composition.

## Notes
`NullOperator` remains a concrete immutable type with `Bool` eltype and two `Int` dimension fields. In-place `mul!` remains nonallocating; out-of-place rectangular application allocates only the returned zero array.

## Tests
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Result: 837 passed, 2 broken, 839 total.