### PR TITLE
Add BlockDiagonalOperator

### DIFF
--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -206,6 +206,7 @@ include("left.jl")
 include("scalar.jl")
 include("matrix.jl")
 include("basic.jl")
+include("block.jl")
 include("batch.jl")
 include("func.jl")
 include("tensor.jl")
@@ -221,6 +222,7 @@ export
     AffineOperator,
     AddVector,
     FunctionOperator,
+    BlockDiagonalOperator,
     TensorProductOperator,
     WOperator,
     StaticWOperator

--- a/src/block.jl
+++ b/src/block.jl
@@ -1,0 +1,167 @@
+"""
+$(TYPEDEF)
+
+Lazy block diagonal operator.
+"""
+struct BlockDiagonalOperator{
+        T,
+        O <: Tuple{Vararg{AbstractSciMLOperator}},
+    } <: AbstractSciMLOperator{T}
+    ops::O
+
+    function BlockDiagonalOperator(ops::Tuple{Vararg{AbstractSciMLOperator}})
+        @assert !isempty(ops)
+        T = mapreduce(eltype, promote_type, ops)
+        return new{T, typeof(ops)}(ops)
+    end
+end
+
+function BlockDiagonalOperator(ops::Union{AbstractMatrix, AbstractSciMLOperator}...)
+    return BlockDiagonalOperator(map(op -> op isa AbstractMatrix ? MatrixOperator(op) : op, ops))
+end
+
+getops(L::BlockDiagonalOperator) = L.ops
+
+function Base.show(io::IO, L::BlockDiagonalOperator)
+    print(io, "BlockDiagonalOperator(")
+    show(io, L.ops[1])
+    for i in 2:length(L.ops)
+        print(io, ", ")
+        show(io, L.ops[i])
+    end
+    return print(io, ")")
+end
+
+function Base.size(L::BlockDiagonalOperator)
+    return (sum(op -> size(op, 1), L.ops), sum(op -> size(op, 2), L.ops))
+end
+
+function Base.convert(::Type{AbstractMatrix}, L::BlockDiagonalOperator)
+    A = zeros(eltype(L), size(L))
+    row_start = 1
+    col_start = 1
+    for op in L.ops
+        m, n = size(op)
+        rows = row_start:(row_start + m - 1)
+        cols = col_start:(col_start + n - 1)
+        A[rows, cols] .= convert(AbstractMatrix, op)
+        row_start += m
+        col_start += n
+    end
+    return A
+end
+has_concretization(L::BlockDiagonalOperator) = all(has_concretization, L.ops)
+
+for op in (:adjoint, :transpose)
+    @eval Base.$op(L::BlockDiagonalOperator) = BlockDiagonalOperator($op.(L.ops)...)
+end
+Base.conj(L::BlockDiagonalOperator) = BlockDiagonalOperator(conj.(L.ops)...)
+
+function update_coefficients(L::BlockDiagonalOperator, u, p, t; kwargs...)
+    ops = map(op -> update_coefficients(op, u, p, t; kwargs...), L.ops)
+    return BlockDiagonalOperator(ops)
+end
+
+function update_coefficients!(L::BlockDiagonalOperator, u, p, t; kwargs...)
+    for op in L.ops
+        update_coefficients!(op, u, p, t; kwargs...)
+    end
+    return nothing
+end
+
+function Base.copy(L::BlockDiagonalOperator)
+    return BlockDiagonalOperator(map(copy, L.ops))
+end
+
+function cache_internals(L::BlockDiagonalOperator, v::AbstractVecOrMat)
+    ops = ()
+    col_start = 1
+    for op in L.ops
+        n = size(op, 2)
+        cols, col_start = _block_range(col_start, n)
+        ops = (ops..., cache_operator(op, _block_view(v, cols)))
+    end
+    return BlockDiagonalOperator(ops)
+end
+
+isconstant(L::BlockDiagonalOperator) = all(isconstant, L.ops)
+islinear(L::BlockDiagonalOperator) = all(islinear, L.ops)
+Base.iszero(L::BlockDiagonalOperator) = all(iszero, L.ops)
+has_adjoint(L::BlockDiagonalOperator) = all(has_adjoint, L.ops)
+has_mul(L::BlockDiagonalOperator) = all(has_mul, L.ops)
+has_mul!(L::BlockDiagonalOperator) = all(has_mul!, L.ops)
+
+function _block_range(start::Int, len::Int)
+    stop = start + len - 1
+    return start:stop, stop + 1
+end
+
+function _block_view(v::AbstractMatrix, rows)
+    return view(v, rows, :)
+end
+function _block_view(v::AbstractVector, rows)
+    return view(v, rows)
+end
+
+function Base.:*(L::BlockDiagonalOperator, v::AbstractVecOrMat)
+    @assert size(v, 1) == size(L, 2)
+    T = promote_type(eltype(L), eltype(v))
+    w = v isa AbstractMatrix ? similar(v, T, (size(L, 1), size(v, 2))) :
+        similar(v, T, size(L, 1))
+    return mul!(w, L, v)
+end
+
+function LinearAlgebra.mul!(
+        w::AbstractVecOrMat, L::BlockDiagonalOperator, v::AbstractVecOrMat
+    )
+    @assert size(v, 1) == size(L, 2)
+    @assert size(w, 1) == size(L, 1)
+    row_start = 1
+    col_start = 1
+    for op in L.ops
+        m, n = size(op)
+        rows, row_start = _block_range(row_start, m)
+        cols, col_start = _block_range(col_start, n)
+        mul!(_block_view(w, rows), op, _block_view(v, cols))
+    end
+    return w
+end
+
+function LinearAlgebra.mul!(
+        w::AbstractVecOrMat,
+        L::BlockDiagonalOperator,
+        v::AbstractVecOrMat,
+        α,
+        β
+    )
+    @assert size(v, 1) == size(L, 2)
+    @assert size(w, 1) == size(L, 1)
+    row_start = 1
+    col_start = 1
+    for op in L.ops
+        m, n = size(op)
+        rows, row_start = _block_range(row_start, m)
+        cols, col_start = _block_range(col_start, n)
+        mul!(_block_view(w, rows), op, _block_view(v, cols), α, β)
+    end
+    return w
+end
+
+function (L::BlockDiagonalOperator)(v::AbstractVecOrMat, u, p, t; kwargs...)
+    L = update_coefficients(L, u, p, t; kwargs...)
+    return L * v
+end
+
+function (L::BlockDiagonalOperator)(
+        w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...
+    )
+    update_coefficients!(L, u, p, t; kwargs...)
+    return mul!(w, L, v)
+end
+
+function (L::BlockDiagonalOperator)(
+        w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...
+    )
+    update_coefficients!(L, u, p, t; kwargs...)
+    return mul!(w, L, v, α, β)
+end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -141,6 +141,51 @@ end
     end
 end
 
+@testset "BlockDiagonalOperator" begin
+    A = rand(3, 2)
+    B = rand(4, 5)
+    L = BlockDiagonalOperator(MatrixOperator(A), MatrixOperator(B))
+    Lmat = [A zeros(3, 5); zeros(4, 2) B]
+    v = rand(7, K)
+    u = rand(7, K)
+    w = zeros(7, K)
+    p = nothing
+    t = 0
+    α = rand()
+    β = rand()
+
+    @test size(L) == (7, 7)
+    @test islinear(L)
+    @test isconstant(L)
+    @test convert(AbstractMatrix, L) ≈ Lmat
+    @test BlockDiagonalOperator(A, B) isa BlockDiagonalOperator
+
+    @test L * v ≈ Lmat * v
+    @test L(v, u, p, t) ≈ Lmat * v
+
+    mul!(w, L, v)
+    @test w ≈ Lmat * v
+
+    copy!(w, rand(7, K))
+    orig_w = copy(w)
+    mul!(w, L, v, α, β)
+    @test w ≈ α * Lmat * v + β * orig_w
+
+    copy!(w, zeros(7, K))
+    L(w, v, u, p, t)
+    @test w ≈ Lmat * v
+
+    copy!(w, rand(7, K))
+    orig_w = copy(w)
+    L(w, v, u, p, t, α, β)
+    @test w ≈ α * Lmat * v + β * orig_w
+
+    x = rand(7)
+    @test L * x ≈ Lmat * x
+    @test convert(AbstractMatrix, L') ≈ Lmat'
+    @test convert(AbstractMatrix, transpose(L)) ≈ transpose(Lmat)
+end
+
 @testset "Unary +/-" begin
     A = MatrixOperator(rand(N, N))
     v = rand(N, K)


### PR DESCRIPTION
Refs #161.

## Summary
This adds a minimal lazy `BlockDiagonalOperator` as a first focused slice of block-operator support.

The implementation is intentionally limited to block diagonal structure rather than general lazy `hcat`/`vcat`/`hvcat` block matrices. That keeps the PR reviewable while covering a common block-structured operator case.

## Changes
- Add exported `BlockDiagonalOperator`.
- Support construction from `AbstractSciMLOperator`s and `AbstractMatrix` blocks.
- Implement `size`, display, dense conversion, copy, coefficient updates, cache recursion, and standard operator traits.
- Implement blockwise `*`, `mul!`, scaled `mul!`, and the SciMLOperators call interface.
- Support `adjoint`, `transpose`, and `conj` blockwise.
- Add regression tests for construction, conversion, matrix/vector application, in-place application, scaled in-place application, call interface, adjoint, and transpose.

## Notes
`BlockDiagonalOperator` stores a typed tuple of child operators. In-place multiplication writes blockwise into views of the destination and does not allocate destination arrays; out-of-place multiplication allocates only the returned result. No new dependencies are added.

## Tests
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Result: 833 passed, 2 broken, 835 total.