### PR TITLE
Add TensorSumOperator

### DIFF
--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -222,6 +222,7 @@ export
     AddVector,
     FunctionOperator,
     TensorProductOperator,
+    TensorSumOperator,
     WOperator,
     StaticWOperator
 
@@ -239,6 +240,7 @@ export update_coefficients!,
     has_mul!,
     has_ldiv,
     has_ldiv!,
-    has_concretization
+    has_concretization,
+    kronsum
 
 end # module

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -196,6 +196,139 @@ has_ldiv!(L::TensorProductOperator) = reduce(&, has_ldiv!.(L.ops))
 
 factorize(L::TensorProductOperator) = TensorProductOperator(factorize.(L.ops)...)
 
+"""
+$(TYPEDEF)
+
+Lazy Kronecker sum operator.
+"""
+struct TensorSumOperator{T, O, P} <: AbstractSciMLOperator{T}
+    ops::O
+    products::P
+
+    function TensorSumOperator(
+            ops::NTuple{2, Union{AbstractMatrix, AbstractSciMLOperator}},
+            products::NTuple{2, AbstractSciMLOperator}
+        )
+        outer, inner = ops
+        @assert issquare(outer)
+        @assert issquare(inner)
+        T = reduce(Base.promote_eltype, ops)
+        return new{T, typeof(ops), typeof(products)}(ops, products)
+    end
+end
+
+function TensorSumOperator(
+        outer::Union{AbstractMatrix, AbstractSciMLOperator},
+        inner::Union{AbstractMatrix, AbstractSciMLOperator}
+    )
+    outer = outer isa AbstractMatrix ? MatrixOperator(outer) : outer
+    inner = inner isa AbstractMatrix ? MatrixOperator(inner) : inner
+    @assert issquare(outer)
+    @assert issquare(inner)
+    products = (
+        TensorProductOperator(outer, IdentityOperator(size(inner, 1))),
+        TensorProductOperator(IdentityOperator(size(outer, 1)), inner),
+    )
+    return TensorSumOperator((outer, inner), products)
+end
+
+"""
+$SIGNATURES
+
+Construct the lazy Kronecker sum `A ⊗ I + I ⊗ B`.
+"""
+kronsum(A::Union{AbstractMatrix, AbstractSciMLOperator}, B::Union{AbstractMatrix, AbstractSciMLOperator}) = TensorSumOperator(A, B)
+
+Base.convert(::Type{AbstractMatrix}, L::TensorSumOperator) = sum(convert.(AbstractMatrix, L.products))
+
+function Base.show(io::IO, L::TensorSumOperator)
+    print(io, "(")
+    show(io, L.ops[1])
+    print(io, " ⊕ ")
+    show(io, L.ops[2])
+    return print(io, ")")
+end
+
+Base.size(L::TensorSumOperator) = size(first(L.products))
+
+for op in (
+        :adjoint,
+        :transpose,
+    )
+    @eval Base.$op(L::TensorSumOperator) = TensorSumOperator($op.(L.ops)...)
+end
+Base.conj(L::TensorSumOperator) = TensorSumOperator(conj.(L.ops)...)
+
+function update_coefficients(L::TensorSumOperator, u, p, t; kwargs...)
+    ops = ()
+    for op in L.ops
+        ops = (ops..., update_coefficients(op, u, p, t; kwargs...))
+    end
+    return TensorSumOperator(ops...)
+end
+
+getops(L::TensorSumOperator) = L.products
+
+function Base.copy(L::TensorSumOperator)
+    return TensorSumOperator(map(copy, L.ops)...)
+end
+
+islinear(L::TensorSumOperator) = all(islinear, L.ops)
+isconvertible(::TensorSumOperator) = false
+has_concretization(L::TensorSumOperator) = all(has_concretization, L.ops)
+Base.iszero(L::TensorSumOperator) = all(iszero, L.ops)
+has_adjoint(L::TensorSumOperator) = all(has_adjoint, L.ops)
+has_mul(L::TensorSumOperator) = all(has_mul, L.ops)
+has_mul!(L::TensorSumOperator) = all(has_mul!, L.ops)
+
+function cache_internals(L::TensorSumOperator, v::AbstractVecOrMat)
+    products = map(op -> cache_operator(op, v), L.products)
+    return TensorSumOperator(L.ops, products)
+end
+
+function Base.:*(L::TensorSumOperator, v::AbstractVecOrMat)
+    return sum(op -> op * v, L.products)
+end
+
+function LinearAlgebra.mul!(w::AbstractVecOrMat, L::TensorSumOperator, v::AbstractVecOrMat)
+    mul!(w, L.products[1], v)
+    mul!(w, L.products[2], v, true, true)
+    return w
+end
+
+function LinearAlgebra.mul!(
+        w::AbstractVecOrMat,
+        L::TensorSumOperator,
+        v::AbstractVecOrMat,
+        α,
+        β
+    )
+    mul!(w, L.products[1], v, α, β)
+    mul!(w, L.products[2], v, α, true)
+    return w
+end
+
+function (L::TensorSumOperator)(v::AbstractVecOrMat, u, p, t; kwargs...)
+    L = update_coefficients(L, u, p, t; kwargs...)
+    return L * v
+end
+
+function (L::TensorSumOperator)(
+        w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t; kwargs...
+    )
+    L = update_coefficients(L, u, p, t; kwargs...)
+    L = cache_operator(L, v)
+    return mul!(w, L, v)
+end
+
+function (L::TensorSumOperator)(
+        w::AbstractVecOrMat, v::AbstractVecOrMat, u, p, t, α, β; kwargs...
+    )
+    L = update_coefficients(L, u, p, t; kwargs...)
+    L = cache_operator(L, v)
+    return mul!(w, L, v, α, β)
+end
+
 # operator application
 function Base.:*(L::TensorProductOperator, v::AbstractVecOrMat)
     outer, inner = L.ops

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -730,6 +730,66 @@ end
     end
 end
 
+@testset "TensorSumOperator" begin
+    A = rand(3, 3)
+    B = rand(4, 4)
+    α = rand()
+    β = rand()
+    p = nothing
+    t = 0.0
+
+    expected = kron(A, Matrix(I, 4, 4)) + kron(Matrix(I, 3, 3), B)
+    L = kronsum(MatrixOperator(A), MatrixOperator(B))
+    L_from_matrices = kronsum(A, B)
+
+    @test L isa TensorSumOperator{Float64}
+    @test L_from_matrices isa TensorSumOperator{Float64}
+    @test size(L) == size(expected)
+    @test islinear(L)
+    @test isconstant(L)
+    @test !iscached(L)
+    @test convert(AbstractMatrix, L) ≈ expected
+    @test convert(AbstractMatrix, L_from_matrices) ≈ expected
+
+    u = rand(size(L, 2), K)
+    v = copy(u)
+    w = zeros(size(L, 1), K)
+
+    @test L * v ≈ expected * v
+    @test L(v, u, p, t) ≈ expected * v
+
+    L = cache_operator(L, u)
+    @test iscached(L)
+
+    mul!(w, L, v)
+    @test w ≈ expected * v
+
+    copy!(w, rand(size(L, 1), K))
+    orig_w = copy(w)
+    mul!(w, L, v, α, β)
+    @test w ≈ α * expected * v + β * orig_w
+
+    copy!(w, zeros(size(L, 1), K))
+    L(w, v, u, p, t)
+    @test w ≈ expected * v
+
+    copy!(w, rand(size(L, 1), K))
+    orig_w = copy(w)
+    L(w, v, u, p, t, α, β)
+    @test w ≈ α * expected * v + β * orig_w
+
+    x = rand(size(L, 2))
+    @test L * x ≈ expected * x
+    @test convert(AbstractMatrix, L') ≈ expected'
+    @test convert(AbstractMatrix, transpose(L)) ≈ transpose(expected)
+    @test_throws AssertionError kronsum(rand(3, 4), B)
+
+    A_update = MatrixOperator(zeros(3, 3); update_func = (A, u, p, t) -> p[1] * Matrix(I, 3, 3))
+    B_update = MatrixOperator(zeros(4, 4); update_func = (B, u, p, t) -> p[2] * Matrix(I, 4, 4))
+    L_update = kronsum(A_update, B_update)
+    @test L_update(v, u, (2.0, 3.0), t) ≈ 5v
+end
+
 @testset "Sparse conversion tests" begin
     A = rand(2, 2)
     opA = MatrixOperator(A)


### PR DESCRIPTION
Refs #53.

## Summary
This adds a minimal lazy `TensorSumOperator` plus the public `kronsum(A, B)` constructor for Kronecker sums of the form `A ⊗ I + I ⊗ B`.

The implementation is intentionally scoped to two square factors and reuses the existing `TensorProductOperator` identity-product paths internally. That gives the roadmap item a small API surface without introducing a separate tensor evaluation engine.

## Changes
- Add exported `TensorSumOperator`.
- Add exported `kronsum(A, B)` constructor.
- Support `AbstractMatrix` and `AbstractSciMLOperator` factors.
- Implement `size`, display, dense conversion, copy, coefficient updates, cache recursion, and standard operator traits.
- Implement `*`, `mul!`, scaled `mul!`, and the SciMLOperators call interface.
- Support `adjoint`, `transpose`, and `conj` by applying the operation to the component factors.
- Add regression tests for dense equivalence, cached and uncached application, scaled in-place application, call interface, vector application, adjoint/transpose, nonsquare rejection, and dynamic coefficient updates.

## Notes
`TensorSumOperator` stores the original two component operators and the two lazy tensor-product terms. In-place multiplication delegates to cached `TensorProductOperator` terms and accumulates into the destination; out-of-place application allocates only the returned result. No new dependencies are added.

## Tests
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Result: 839 passed, 2 broken, 841 total.