### PR TITLE
Add exp dispatch for scalar operators

### DIFF
--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -379,6 +379,15 @@ function DiagonalOperator(
 end
 LinearAlgebra.Diagonal(L::MatrixOperator) = MatrixOperator(Diagonal(L.A))
 
+function LinearAlgebra.exp(L::MatrixOperator{T, <:Diagonal}) where {T}
+    update_func = (
+        A, u, p, t;
+        kwargs...,
+    ) -> update_coefficients(L, u, p, t; kwargs...).A |>
+        exp
+    return MatrixOperator(exp(L.A); update_func = update_func, accepted_kwargs = NoKwargFilter())
+end
+
 function Base.show(io::IO, L::MatrixOperator{T, <:Diagonal}) where {T}
     n = length(L.A.diag)
     return print(io, "DiagonalOperator($n × $n)")

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -215,6 +215,16 @@ Base.one(::Type{<:AbstractSciMLScalarOperator}) = ScalarOperator(true)
 Base.zero(::Type{<:AbstractSciMLScalarOperator}) = ScalarOperator(false)
 Base.abs(α::ScalarOperator) = abs(α.val)
 
+function LinearAlgebra.exp(α::AbstractSciMLScalarOperator)
+    update_func = (
+        oldval, u, p, t;
+        kwargs...,
+    ) -> update_coefficients(α, u, p, t; kwargs...) |>
+        concretize |>
+        exp
+    return ScalarOperator(exp(concretize(α)); update_func = update_func, accepted_kwargs = NoKwargFilter())
+end
+
 Base.iszero(α::ScalarOperator) = iszero(α.val)
 
 getops(α::ScalarOperator) = (α.val,)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -245,6 +245,11 @@ end
     orig_w = copy(w)
     D(w, v, u, p, t, α, β)
     @test w ≈ α * expected + β * orig_w
+
+    expD = exp(D)
+    @test expD isa MatrixOperator
+    @test expD.A isa Diagonal
+    @test expD(v, u, p, t) ≈ exp.(p * t) .* v
 end
 
 @testset "Batched Diagonal Operator" begin

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -57,6 +57,11 @@ K = 12
     aa = ScalarOperator(a_scalar)
     @test axpy!(aa, X, Y) ≈ a_scalar * X + Z
 
+    expα = exp(α)
+    @test expα isa ScalarOperator
+    @test convert(Number, expα) ≈ exp(x)
+    @test expα * u ≈ exp(x) * u
+
     # Tests with the new interface
     v = copy(u)  # Action vector
     w = zeros(N, K)  # Output vector
@@ -120,6 +125,10 @@ end
     @test β * u ≈ u
     @inferred convert(Float32, β)
     @test convert(Number, β) ≈ true
+
+    β = exp(α + α)
+    @test β isa ScalarOperator
+    @test β(v, u, nothing, 0.0) ≈ exp(2x) * v
 
     # Test combination with other operators
     for op in (MatrixOperator(rand(N, N)), SciMLOperators.IdentityOperator(N))
@@ -261,4 +270,7 @@ end
     w_orig = copy(w_test)
     γ_added(w_test, v, u, p, t, c, d; dtgamma)
     @test w_test ≈ c * (dtgamma + p) * v + d * w_orig
+
+    δ = exp(γ)
+    @test δ(v, u, p, t; dtgamma) ≈ exp(dtgamma) * v
 end


### PR DESCRIPTION
Closes #258.

## Summary
This adds specialized `exp` dispatches for scalar and diagonal SciMLOperators so they do not fall through to the generic dense-matrix fallback.

## Root Cause
`LinearAlgebra.exp(L::AbstractSciMLOperator)` currently calls `exp(Matrix(L))`. That is not valid for scalar operators, which concretize to numbers rather than matrices, and it also densifies diagonal operators unnecessarily.

## Changes
- Add `exp(::AbstractSciMLScalarOperator)` returning a `ScalarOperator`.
- Preserve update behavior for dynamic scalar operators by updating the wrapped scalar before exponentiation.
- Add `exp(::MatrixOperator{<:Any,<:Diagonal})` so `DiagonalOperator` exponentials preserve diagonal structure.
- Preserve update behavior for dynamic diagonal operators.
- Add regressions for constant scalar exp, composed scalar exp, keyword-updated scalar exp, and dynamically updated diagonal exp.

## Notes
The scalar dispatch keeps the result as a lazy scalar operator. The diagonal dispatch keeps the result as a `MatrixOperator` backed by a `Diagonal`, avoiding dense allocation in the operator representation. No new dependencies are added.

## Tests
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Result: 828 passed, 2 broken, 830 total.