### PR TITLE
Improve FunctionOperator inverse error

### DIFF
--- a/src/func.jl
+++ b/src/func.jl
@@ -773,6 +773,12 @@ has_mul!(::FunctionOperator{iip}) where {iip} = true
 has_ldiv(L::FunctionOperator{iip}) where {iip} = !(L.op_inverse isa Nothing)
 has_ldiv!(L::FunctionOperator{iip}) where {iip} = iip & !(L.op_inverse isa Nothing)
 
+function _assert_has_inverse(L::FunctionOperator)
+    has_ldiv(L) && return nothing
+    msg = "Cannot divide by FunctionOperator without an inverse. Provide `op_inverse` when constructing the operator."
+    throw(ArgumentError(msg))
+end
+
 function _sizecheck(L::FunctionOperator, v, w)
     sizes = L.traits.sizes
     if L.traits.batch
@@ -897,6 +903,7 @@ end
 
 function Base.:\(L::FunctionOperator{iip, true}, v::AbstractArray) where {iip}
     _sizecheck(L, nothing, v)
+    _assert_has_inverse(L)
     _, V, vec_output = _unvec(L, nothing, v)
 
     W = L.op_inverse(V, L.u, L.p, L.t; L.traits.kwargs...)
@@ -906,6 +913,7 @@ end
 
 function Base.:\(L::FunctionOperator{iip, false}, v::AbstractArray) where {iip}
     _sizecheck(L, nothing, v)
+    _assert_has_inverse(L)
     _, V, vec_output = _unvec(L, nothing, v)
 
     W, _ = L.cache
@@ -962,6 +970,7 @@ end
 
 function LinearAlgebra.ldiv!(w::AbstractArray, L::FunctionOperator{true}, v::AbstractArray)
     _sizecheck(L, v, w)
+    _assert_has_inverse(L)
     W, V, _ = _unvec(L, w, v)
 
     L.op_inverse(W, V, L.u, L.p, L.t; L.traits.kwargs...)
@@ -970,11 +979,11 @@ function LinearAlgebra.ldiv!(w::AbstractArray, L::FunctionOperator{true}, v::Abs
 end
 
 function LinearAlgebra.ldiv!(L::FunctionOperator{true}, v::AbstractArray)
-    W, _ = L.cache
-
     _sizecheck(L, nothing, v)
+    _assert_has_inverse(L)
     V, _, vec_output = _unvec(L, v, nothing)
 
+    W, _ = L.cache
     copy!(W, V)
     L.op_inverse(W, V, L.u, L.p, L.t; L.traits.kwargs...) # ldiv!(U, L, V)
 
@@ -984,6 +993,7 @@ end
 
 function LinearAlgebra.ldiv!(w::AbstractArray, L::FunctionOperator{false}, v::AbstractArray)
     _sizecheck(L, v, w)
+    _assert_has_inverse(L)
     W, V, _ = _unvec(L, w, v)
 
     W .= L.op_inverse(V, L.u, L.p, L.t; L.traits.kwargs...)
@@ -993,6 +1003,7 @@ end
 
 function LinearAlgebra.ldiv!(L::FunctionOperator{false}, v::AbstractArray)
     _sizecheck(L, nothing, v)
+    _assert_has_inverse(L)
     V, _, vec_output = _unvec(L, v, nothing)
 
     V .= L.op_inverse(V, L.u, L.p, L.t; L.traits.kwargs...) # ldiv!(W, L, V)

--- a/test/func.jl
+++ b/test/func.jl
@@ -151,6 +151,24 @@ end
     @test has_ldiv(op2)
     @test has_ldiv!(op2)
 
+    op1_no_inverse = FunctionOperator(f1, v; ifcache = false, islinear = true)
+    op2_no_inverse = FunctionOperator(f2, v, w; ifcache = false, islinear = true)
+
+    inverse_error(f) = try
+        f()
+        nothing
+    catch err
+        err
+    end
+
+    err = inverse_error(() -> op1_no_inverse \ v)
+    @test err isa ArgumentError
+    @test occursin("op_inverse", sprint(showerror, err))
+
+    err = inverse_error(() -> ldiv!(w, op2_no_inverse, v))
+    @test err isa ArgumentError
+    @test occursin("op_inverse", sprint(showerror, err))
+
     @test !iscached(op1)
     @test !iscached(op2)
     @test !op1.traits.has_mul5


### PR DESCRIPTION
## Summary

Closes #251.

This PR improves the error users see when applying inverse operations to a `FunctionOperator` constructed without `op_inverse`. Instead of falling through to a `Nothing` callable `MethodError`, the inverse paths now throw an `ArgumentError` that tells users to provide `op_inverse` when constructing the operator.

## Root Cause

`has_ldiv` already reported that a `FunctionOperator` without `op_inverse` cannot be divided by, but the `\` and `ldiv!` implementations called `L.op_inverse` directly. When `op_inverse === nothing`, that produced the opaque `objects of type Nothing are not callable` failure from issue #251.

## Changes

- Add an internal `_assert_has_inverse` guard for `FunctionOperator` inverse operations.
- Apply the guard to both out-of-place and in-place inverse paths: `F \ v`, `ldiv!(w, F, v)`, and `ldiv!(F, v)`.
- Add regression tests confirming missing inverses throw `ArgumentError` and mention `op_inverse`.

## Type Stability / Allocations

The success path keeps the existing public API and inverse dispatch shape. The added guard is a small predicate check before calling the already-stored inverse function; the error message allocation only occurs on the missing-inverse error path.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test(; test_args=["func.jl"])'` passed with `823` passing tests and `2` broken tests.