### PR TITLE
Add LoopVectorization tensor-product fast path extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,12 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 
 [weakdeps]
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [extensions]
+SciMLOperatorsLoopVectorizationExt = "LoopVectorization"
 SciMLOperatorsSparseArraysExt = "SparseArrays"
 SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
@@ -22,6 +24,7 @@ Accessors = "0.1.42"
 ArrayInterface = "7.19"
 DocStringExtensions = "0.9.4"
 LinearAlgebra = "1.10"
+LoopVectorization = "0.12"
 SparseArrays = "1.10"
 StaticArraysCore = "1"
 julia = "1.10"

--- a/ext/SciMLOperatorsLoopVectorizationExt.jl
+++ b/ext/SciMLOperatorsLoopVectorizationExt.jl
@@ -1,0 +1,46 @@
+module SciMLOperatorsLoopVectorizationExt
+
+import LoopVectorization: @turbo
+import SciMLOperators
+
+const StridedMatrixOperator = SciMLOperators.MatrixOperator{<:Any, <:StridedMatrix}
+
+SciMLOperators._has_tensor_outer_mul_fast(::StridedMatrixOperator) = true
+
+function SciMLOperators._tensor_outer_mul_fast!(
+        w, outer::StridedMatrixOperator, C, mi::Int, mo::Int, no::Int, k::Int
+    )
+    A = outer.A
+    C = reshape(C, (mi, no, k))
+    W = reshape(w, (mi, mo, k))
+
+    @turbo for j in 1:k, m in 1:mo, i in 1:mi
+        acc = zero(eltype(w))
+        for o in 1:no
+            acc += A[m, o] * C[i, o, j]
+        end
+        W[i, m, j] = acc
+    end
+
+    return w
+end
+
+function SciMLOperators._tensor_outer_mul_fast!(
+        w, outer::StridedMatrixOperator, C, mi::Int, mo::Int, no::Int, k::Int, α, β
+    )
+    A = outer.A
+    C = reshape(C, (mi, no, k))
+    W = reshape(w, (mi, mo, k))
+
+    @turbo for j in 1:k, m in 1:mo, i in 1:mi
+        acc = zero(eltype(w))
+        for o in 1:no
+            acc += A[m, o] * C[i, o, j]
+        end
+        W[i, m, j] = α * acc + β * W[i, m, j]
+    end
+
+    return w
+end
+
+end

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -413,6 +413,9 @@ end
 # helper functions
 const PERM = (2, 1, 3)
 
+_has_tensor_outer_mul_fast(outer) = false
+function _tensor_outer_mul_fast! end
+
 function outer_mul(L::TensorProductOperator, v::AbstractVecOrMat, C::AbstractVecOrMat)
     outer, inner = L.ops
 
@@ -465,6 +468,11 @@ function outer_mul!(w::AbstractVecOrMat, L::TensorProductOperator, v::AbstractVe
         return w
     end
 
+    if _has_tensor_outer_mul_fast(outer)
+        _tensor_outer_mul_fast!(w, outer, C1, mi, mo, no, k)
+        return w
+    end
+
     C2, C3 = L.cache[2:3]
 
     C1 = reshape(C1, (mi, no, k))
@@ -500,6 +508,11 @@ function outer_mul!(
         W = reshape(w, (mi, mo))
         C = reshape(v, (mi, no))
         mul!(transpose(W), outer, transpose(C), α, β)
+        return w
+    end
+
+    if _has_tensor_outer_mul_fast(outer)
+        _tensor_outer_mul_fast!(w, outer, v, mi, mo, no, k, α, β)
         return w
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -10,5 +11,6 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 FFTW = "1.10.0"
+LoopVectorization = "0.12"
 SafeTestsets = "0.1.0"
 Zygote = "0.7.10"

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -2,6 +2,7 @@ using SciMLOperators, LinearAlgebra
 using SparseArrays
 using Random
 using Test
+using LoopVectorization
 
 using SciMLOperators: InvertibleOperator, InvertedOperator, ⊗, AbstractSciMLOperator
 using FFTW


### PR DESCRIPTION
## Revision note

Thanks for the early review comments. I revised the PR to separate fast-path availability/control flow from the mutating implementation call, rewrote the `k == 1`/batched fast-path branch so the flow is explicit, and removed unrelated cache-slice edits plus a redundant test block. Hopefully this is now back on track as a minimal extension-backed optimization.

## Summary

This PR adds an optional fast path for batched `TensorProductOperator` multiplication when the outer operator is a `MatrixOperator` wrapping a CPU `StridedMatrix`.

The core tensor implementation now exposes a small internal backend-neutral hook, `_tensor_outer_mul_fast!`, guarded by a separate `_has_tensor_outer_mul_fast` predicate. The existing generic implementation remains the fallback and still uses only the operator interface (`mul!`) after reshaping/permuting into the layout it needs. That keeps arbitrary matrix-free operators, sparse matrices, GPU arrays, and other non-strided operators on the abstraction-preserving path.

A new `SciMLOperatorsLoopVectorizationExt` extension overloads this hook with an `@turbo` loop for the narrow dense-strided `MatrixOperator` case. `LoopVectorization` is a weak dependency and a test dependency, not a hard dependency of SciMLOperators.

## Backend design

The hook is intentionally not named after LoopVectorization. Core owns a generic availability predicate plus an implementation hook:

```julia
_has_tensor_outer_mul_fast(outer) = false
function _tensor_outer_mul_fast! end
```

The predicate keeps control flow separate from the mutating fast-path call. Backend extensions opt in by overloading the predicate for supported operator types and providing the corresponding `_tensor_outer_mul_fast!` methods.

That means LoopVectorization is only the first backend. If LoopModels, or another successor backend, becomes the preferred implementation later, it can live in its own extension and overload the same hook without changing the core tensor-product algorithm or public API.

The intended backend-switching model is:

- Core SciMLOperators owns the generic fallback and the backend-neutral hook.
- `SciMLOperatorsLoopVectorizationExt` owns today’s `@turbo` dense-strided implementation.
- The same extension design could support an opt-in `@tturbo` method later, for users who want to experiment with threaded LoopVectorization behavior, without changing the core tensor code. This PR intentionally uses only `@turbo` as the safer default because it avoids thread oversubscription concerns with threaded BLAS.
- A future `SciMLOperatorsLoopModelsExt` can provide the same hook for LoopModels once its API is ready.
- A future GPU backend could also overload the same hook from a CUDA/KernelAbstractions-style extension, but this PR does not add a GPU kernel.
- If no backend is loaded, behavior remains unchanged.

## GPU compatibility

This PR should not change existing GPU behavior by dispatch. The new LoopVectorization method only applies to `MatrixOperator` wrapping a `StridedMatrix`, so GPU arrays such as `CuArray` should not be caught by the CPU scalar-indexing `@turbo` path. GPU-backed operators continue to use the existing generic fallback, which relies on the current `permutedims!`/`mul!` behavior for those array/operator types.

I did not run GPU tests locally, so this is a dispatch/abstraction argument rather than a measured GPU validation.

## Performance notes

Local benchmarks on the existing `benchmarks/tensor.jl` setup showed the extension active only when `LoopVectorization` is loaded. These numbers were collected on Apple Silicon, so they should be treated as a conservative local check rather than the expected best case. The improvement may be larger on Intel AVX/AVX2 machines, which are closer to the hardware context discussed in #58 and where LoopVectorization's SIMD code generation has historically shown larger gains.

I also tried the other idea from #58: replacing explicit `permutedims!` calls with `PermutedDimsArray`. That benchmarked substantially worse for the dense batched cases, likely because BLAS then sees a lazy/strided permuted input instead of contiguous storage. This PR therefore keeps the existing explicit permutation fallback and only bypasses it for the narrow `@turbo` extension path.

Without `LoopVectorization`, the fallback path remains at baseline:

```text
⊗(A, B) cached mul!:          ~29.1 μs, 5 allocs
⊗(A, I) cached mul!:          ~19.8 μs, 4 allocs
⊗(⊗(A, B), C) cached mul!:   ~283.7 μs, 10 allocs
⊗(A, ⊗(B, C)) cached mul!:   ~283.5 μs, 10 allocs
```

With `LoopVectorization` loaded:

```text
⊗(A, B) cached mul!:          ~17.0 μs, 3 allocs
⊗(A, I) cached mul!:           ~7.1 μs, 2 allocs
⊗(⊗(A, B), C) cached mul!:   ~234.5 μs, 8 allocs
⊗(A, ⊗(B, C)) cached mul!:   ~188.7 μs, 6 allocs
```

This follows the discussion in #58: avoid the generic `permutedims! + mul! + permutedims!` path only where fast indexing is actually valid, rather than assuming all operators are indexable.

## Tests

- Added `LoopVectorization` to the test environment so the existing dense batched `TensorProductOperator` plain/scaled `mul!` tests exercise the extension path.
- `Pkg.test()` passes locally with `LoopVectorization` in the test environment:

```text
SciMLOperators | 823 passed, 2 broken
```