### PR TITLE
Share same cache among similar operators in `AddedOperator`

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -42,6 +42,20 @@ SciMLOperators.has_tensor_outer_mul_fast
 SciMLOperators.tensor_outer_mul_fast!
 ```
 
+### Sharing scratch space between the summands of an `AddedOperator`
+
+`mul!` applies the summands of an `AddedOperator` one after another, so no two of their
+caches are ever live at the same time and a summand can reuse the scratch of an earlier
+one. An operator type takes part by defining `getcache`, and can additionally avoid
+allocating a cache it would only discard by defining `adopt_cache`. Both default to
+declining, so a type that defines neither behaves exactly as it did before.
+
+```@docs
+SciMLOperators.getcache
+SciMLOperators.update_cache
+SciMLOperators.adopt_cache
+```
+
 ## Note About Affine Operators
 
 Affine operators are operators that have the action `Q*x = A*x + b`. These operators have

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -50,6 +50,17 @@ one. An operator type takes part by defining `getcache`, and can additionally av
 allocating a cache it would only discard by defining `adopt_cache`. Both default to
 declining, so a type that defines neither behaves exactly as it did before.
 
+A wrapper holding no scratch of its own, such as `ScaledOperator`, forwards all three hooks
+to the operator it wraps, so `2A + 3B` and `A - B` share as `A + B` does. A new wrapper of
+that kind should do the same.
+
+!!! warning "Concurrency"
+    
+    Applying a cached operator from several tasks at once was never safe, because they
+    would write to the same scratch. Once its summands share scratch they are not
+    independently safe either, so code that hand-parallelizes over the `ops` of an
+    `AddedOperator` needs its own uncached copies.
+
 ```@docs
 SciMLOperators.getcache
 SciMLOperators.update_cache

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -334,7 +334,8 @@ export update_coefficients!,
             :ScaledOperator, :AddedOperator, :ComposedOperator,
             :InvertedOperator, :AdjointOperator, :TransposedOperator,
             :AddedScalarOperator, :ComposedScalarOperator, :InvertedScalarOperator,
-            :has_tensor_outer_mul_fast, :tensor_outer_mul_fast!
+            :has_tensor_outer_mul_fast, :tensor_outer_mul_fast!,
+            :getcache, :update_cache, :adopt_cache
         )
     )
 end

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -477,6 +477,22 @@ function cache_internals(L::ScaledOperator, v::AbstractVecOrMat)
     return L
 end
 
+# A scaling holds no scratch of its own, so it is transparent to the sharing described in
+# `getcache`: the cache one field down is exactly as interchangeable as one held directly.
+# Forwarding matters more than it looks — `A - B` lowers to `AddedOperator(A, -B)` with
+# `-B` a `ScaledOperator`, so without this the commonest sum of all shares nothing.
+getcache(L::ScaledOperator) = getcache(L.L)
+update_cache(L::ScaledOperator, new_cache) = @reset L.L = update_cache(L.L, new_cache)
+
+function adopt_cache(L::ScaledOperator, cache, v)
+    inner = adopt_cache(L.L, cache, v)
+    inner === nothing && return nothing
+
+    @reset L.L = inner
+    @reset L.λ = cache_operator(L.λ, v)
+    return L
+end
+
 # getindex
 Base.getindex(L::ScaledOperator, i::Int) = L.coeff * L.L[i]
 Base.getindex(L::ScaledOperator, I::Vararg{Int, N}) where {N} = L.λ * L.L[I...]

--- a/src/basic.jl
+++ b/src/basic.jl
@@ -789,8 +789,23 @@ has_adjoint(L::AddedOperator) = all(has_adjoint, L.ops)
 @generated function cache_internals(L::AddedOperator, v::AbstractVecOrMat)
     ops_types = L.parameters[2].parameters
     N = length(ops_types)
-    cached = [:(cache_operator(L.ops[$i], v)) for i in 1:N]
-    return :(AddedOperator($(Expr(:tuple, cached...))))
+    syms = [Symbol(:op_, i) for i in 1:N]
+
+    # `mul!` applies the summands one after another, so no two of their caches are ever
+    # live at the same time and a summand can reuse the scratch of an earlier one. Only
+    # summands of the same concrete type can qualify — that is what pins their element
+    # types — so the candidates are picked out here, at compile time, and each summand
+    # tries them all before allocating anything of its own.
+    stmts = map(1:N) do i
+        donors = Expr(:tuple, syms[findall(j -> ops_types[j] === ops_types[i], 1:(i - 1))]...)
+        earlier = Expr(:tuple, syms[1:(i - 1)]...)
+        return :($(syms[i]) = _cache_summand(L.ops[$i], $donors, $earlier, v))
+    end
+
+    return quote
+        $(stmts...)
+        return AddedOperator($(Expr(:tuple, syms...)))
+    end
 end
 
 getindex(L::AddedOperator, i::Int) = sum(op -> op[i], L.ops)
@@ -1003,6 +1018,8 @@ function update_coefficients(L::ComposedOperator, u, p, t; kwargs...)
 end
 
 getops(L::ComposedOperator) = L.ops
+getcache(L::ComposedOperator) = L.cache
+adopt_cache(L::ComposedOperator, cache, v) = cache_internals(update_cache(L, cache), v)
 
 # Copy method to avoid aliasing
 function Base.copy(L::ComposedOperator)
@@ -1345,6 +1362,8 @@ function update_coefficients(L::InvertedOperator, u, p, t; kwargs...)
 end
 
 getops(L::InvertedOperator) = (L.L,)
+getcache(L::InvertedOperator) = L.cache
+adopt_cache(L::InvertedOperator, cache, v) = cache_internals(update_cache(L, cache), v)
 islinear(L::InvertedOperator) = islinear(L.L)
 isconvertible(::InvertedOperator) = false
 

--- a/src/func.jl
+++ b/src/func.jl
@@ -212,6 +212,17 @@ function set_cache(
     )
 end
 
+getcache(L::FunctionOperator) = L.cache
+# `cache` is a type parameter here, so it cannot be swapped with `@reset`.
+update_cache(L::FunctionOperator, new_cache) = set_cache(L, new_cache)
+
+# Deliberately no `adopt_cache` method: `cache_self` sizes its buffers from
+# `traits.sizes`, the input/output *array* shapes, which `size(L) == traits.size` does not
+# expose, so two same-typed operators of equal `size` can still need different buffers.
+# `cache_operator` also does batch-size fixup that skipping straight to `cache_internals`
+# would miss. `FunctionOperator` still shares via the post-hoc path in `_deduplicate_cache`,
+# which compares buffers that have actually been allocated.
+
 function input_eltype(
         ::FunctionOperator{
             iip, oop, mul5, T, F, Fa, Fi, Fai, Tr, U, P, Tt, C,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -193,6 +193,20 @@ earlier one whose cache has the identical type and identically sized slots, so o
 this for operators where two such caches really are interchangeable — including which
 slots deliberately alias each other. The `nothing` default keeps a type out of it entirely.
 
+Two further conditions come with defining it. The first is on the operator's own
+`cache_self`: it must treat the buffers it is handed as a template to `similar`, `zero` or
+`reshape` and never retain a reference to them, since the whole point is that those buffers
+may afterwards be replaced by an earlier summand's. Every `cache_self` in this package does.
+The second is on the caller: applying the summands of an `AddedOperator` concurrently, by
+hand, is no longer safe once they share scratch — a cached operator was never safe to apply
+concurrently, but now its summands are not independently safe either.
+
+A wrapper that holds no scratch of its own — `ScaledOperator`, `AdjointOperator`,
+`TransposedOperator` — is transparent to all of this and forwards `getcache`,
+[`update_cache`](@ref) and [`adopt_cache`](@ref) to the operator it wraps. A new wrapper of
+that kind should do the same; without it the operator underneath drops out of sharing even
+though its cache would have qualified.
+
 See also [`adopt_cache`](@ref), which additionally spares the operator from allocating a
 cache it would only discard.
 """
@@ -210,8 +224,22 @@ update_cache(op::AbstractSciMLOperator, new_cache) = @reset op.cache = new_cache
 # are left to check. Anything else is conservatively treated as not interchangeable.
 _slots_match(a::AbstractArray, b::AbstractArray) = size(a) == size(b)
 _slots_match(::Nothing, ::Nothing) = true
-_slots_match(a::Tuple, b::Tuple) = all(map(_slots_match, a, b))
+function _slots_match(a::NTuple{N, Any}, b::NTuple{N, Any}) where {N}
+    return all(map(_slots_match, a, b)) && _aliasing_matches(a, b)
+end
 _slots_match(a, b) = false
+
+# Which slots deliberately point at the same buffer is part of the layout, not an accident
+# of it: `TensorProductOperator` folds two of its slots into one exactly when both factors
+# are square. Comparing the pattern keeps an operator that needs distinct buffers from ever
+# being handed a cache that shares one, instead of relying on the sizes to give it away.
+function _aliasing_matches(a::NTuple{N, Any}, b::NTuple{N, Any}) where {N}
+    return all(
+        ntuple(Val(N)) do i
+            all(ntuple(j -> (a[i] === a[j]) === (b[i] === b[j]), Val(N)))
+        end
+    )
+end
 
 # Having the same cache type is settled at compile time; only the sizes cost anything at
 # run time. Caches of differing type take the second method and are never interchanged.
@@ -246,6 +274,9 @@ Return `op` set up for in-place use with `v` using `cache` — the cache of an o
 already established as interchangeable with it — instead of allocating buffers of its own.
 Return `nothing` to decline, in which case `op` is cached the ordinary way and then offered
 the same cache after the fact, which costs an allocation that is immediately discarded.
+What comes back must report `cache` as its own — [`getcache`](@ref) on it is checked against
+what was handed over, and anything else is treated as having declined, since an
+implementation that quietly allocated instead would otherwise skip the ordinary path too.
 
 Declining is the default, because there is no implementation that is correct for every
 operator: one that follows the `cache_self`/`cache_internals` split opts in with
@@ -298,7 +329,13 @@ function _try_adopt(op, donors::Tuple, v)
 
     if cache !== nothing && _shape_signature(op) == _shape_signature(donor)
         adopted = adopt_cache(op, cache, v)
-        adopted === nothing || return adopted
+        # An `adopt_cache` that comes back reporting something other than the cache it was
+        # handed did not use it — it allocated buffers of its own, and taking it at its word
+        # would skip the post-hoc path as well and leave the summand sharing nothing. Take
+        # the ordinary route instead, where `_deduplicate_cache` still gets its turn.
+        if adopted !== nothing && getcache(adopted) === cache
+            return adopted
+        end
     end
 
     return _try_adopt(op, Base.tail(donors), v)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -181,6 +181,129 @@ end
 cache_self(L::AbstractSciMLOperator, ::AbstractVecOrMat) = L
 cache_internals(L::AbstractSciMLOperator, ::AbstractVecOrMat) = L
 
+"""
+$SIGNATURES
+
+Return the cache held by `op`, or `nothing` when it holds none.
+
+Defining this method opts `op`'s type into the scratch sharing `AddedOperator` does
+between its summands, which is sound because `mul!` applies them strictly serially and no
+two of their caches are ever live at once. A summand may then be given the cache of an
+earlier one whose cache has the identical type and identically sized slots, so only define
+this for operators where two such caches really are interchangeable — including which
+slots deliberately alias each other. The `nothing` default keeps a type out of it entirely.
+
+See also [`adopt_cache`](@ref), which additionally spares the operator from allocating a
+cache it would only discard.
+"""
+getcache(::AbstractSciMLOperator) = nothing
+
+"""
+$SIGNATURES
+
+Replace `op`'s cache with `new_cache`. Only ever called with a `new_cache` of exactly
+the same type as the one it replaces, so `op`'s type is unchanged.
+"""
+update_cache(op::AbstractSciMLOperator, new_cache) = @reset op.cache = new_cache
+
+# Identical cache types already pin element type, layout and device, so only the extents
+# are left to check. Anything else is conservatively treated as not interchangeable.
+_slots_match(a::AbstractArray, b::AbstractArray) = size(a) == size(b)
+_slots_match(::Nothing, ::Nothing) = true
+_slots_match(a::Tuple, b::Tuple) = all(map(_slots_match, a, b))
+_slots_match(a, b) = false
+
+# Having the same cache type is settled at compile time; only the sizes cost anything at
+# run time. Caches of differing type take the second method and are never interchanged.
+function _swap_cache(op, mine::C, theirs::C) where {C}
+    return _slots_match(mine, theirs) ? update_cache(op, theirs) : nothing
+end
+_swap_cache(op, mine, theirs) = nothing
+
+# Point an *already cached* `op` at an interchangeable cache held by one of the `earlier`
+# summands, so its own buffers can be collected. Leaves `op` alone when nothing matches.
+#
+# This does not make `op` work — `cache_operator` already did that — it makes it smaller.
+# Nothing here describes what a cache ought to look like: the buffers being compared have
+# already been allocated, so there is no second description of the layout that could drift
+# out of sync with `cache_self`.
+_deduplicate_cache(op, ::Tuple{}) = op
+
+function _deduplicate_cache(op, earlier::Tuple)
+    mine = getcache(op)
+    mine === nothing && return op
+
+    swapped = _swap_cache(op, mine, getcache(first(earlier)))
+    swapped === nothing || return swapped
+
+    return _deduplicate_cache(op, Base.tail(earlier))
+end
+
+"""
+$SIGNATURES
+
+Return `op` set up for in-place use with `v` using `cache` — the cache of an operator
+already established as interchangeable with it — instead of allocating buffers of its own.
+Return `nothing` to decline, in which case `op` is cached the ordinary way and then offered
+the same cache after the fact, which costs an allocation that is immediately discarded.
+
+Declining is the default, because there is no implementation that is correct for every
+operator: one that follows the `cache_self`/`cache_internals` split opts in with
+
+    adopt_cache(op::MyOperator, cache, v) = cache_internals(update_cache(op, cache), v)
+
+whereas one that defines its own `cache_operator` must instead do whatever that does, minus
+the allocation — the line above would silently skip its internal caching entirely.
+
+Defining this asks more of an operator than [`getcache`](@ref) alone. `getcache` only
+claims that two caches of the same type with the same slot sizes are interchangeable, and
+that is checked against buffers that already exist. This additionally claims that what
+`cache_self` builds is a function of the operator's type, its operands' sizes and `v`, since
+that is what the caller compares before any buffer exists. Leave it undefined when the cache
+depends on anything else — `FunctionOperator` does, because it sizes buffers from
+`traits.sizes`, which `size` does not expose.
+"""
+adopt_cache(::AbstractSciMLOperator, cache, v) = nothing
+
+# Everything `cache_self` may read: the operator's own size and, recursively, its operands'.
+# `adopt_cache`'s contract is that a cache layout follows from the operator's type together
+# with these, so equal types and equal signatures mean interchangeable caches.
+_shape_signature(x) = ()
+_shape_signature(x::AbstractArray) = size(x)
+_shape_signature(L::AbstractSciMLOperator) = (size(L), map(_shape_signature, getops(L)))
+
+# Cache `op`, taking the buffers of one of the `donors` outright when they are
+# interchangeable, so that nothing is allocated only to be thrown away.
+#
+# Every donor already shares `op`'s concrete type — the caller settles that at compile time,
+# which pins every element type — so only their shape signatures are compared here. The two
+# checks are not redundant: `M(8, 8) * M(8, 8)` and `M(8, 16) * M(16, 8)` have identical
+# types and identical overall size while needing different cache layouts.
+#
+# Falls back to caching `op` normally and deduplicating afterwards. That happens when no
+# donor fits, and for any type that has not opted into `adopt_cache`.
+function _cache_summand(op, donors::Tuple, earlier::Tuple, v)
+    adopted = _try_adopt(op, donors, v)
+    adopted === nothing || return adopted
+
+    return _deduplicate_cache(cache_operator(op, v), earlier)
+end
+
+# Walk the same-typed candidates in order, taking the first whose sizes also line up.
+_try_adopt(op, ::Tuple{}, v) = nothing
+
+function _try_adopt(op, donors::Tuple, v)
+    donor = first(donors)
+    cache = getcache(donor)
+
+    if cache !== nothing && _shape_signature(op) == _shape_signature(donor)
+        adopted = adopt_cache(op, cache, v)
+        adopted === nothing || return adopted
+    end
+
+    return _try_adopt(op, Base.tail(donors), v)
+end
+
 ###
 # operator traits
 ###

--- a/src/left.jl
+++ b/src/left.jl
@@ -175,6 +175,18 @@ for (op, LType, VType) in (
         return L
     end
 
+    # Like `ScaledOperator`, these wrappers hold no scratch of their own and so are
+    # transparent to the sharing described in `getcache`. The reshape is the same one
+    # `cache_internals` above does: what the wrapper is applied to is not what the operator
+    # it wraps is applied to.
+    @eval getcache(L::$LType) = getcache(L.L)
+    @eval update_cache(L::$LType, new_cache) = @reset L.L = update_cache(L.L, new_cache)
+
+    @eval function adopt_cache(L::$LType, cache, u::AbstractVecOrMat)
+        inner = adopt_cache(L.L, cache, reshape(u, size(L, 1)))
+        return inner === nothing ? nothing : (@reset L.L = inner)
+    end
+
     # operator application
     @eval Base.:*(u::$VType, L::$LType) = $op(L.L * u.parent)
     @eval Base.:/(u::$VType, L::$LType) = $op(L.L \ u.parent)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -490,7 +490,11 @@ function cache_self(L::TensorProductOperator, v::AbstractMatrix)
 end
 
 function cache_internals(L::TensorProductOperator, v::AbstractVecOrMat)
-    if !iscached(L)
+    # Only this operator's own buffers are in question here — `iscached` is recursive, so
+    # testing it would re-run `cache_self` and throw away a perfectly good cache whenever a
+    # factor happens to be uncached, which is exactly the state `cache_operator` calls this
+    # in. `ComposedOperator` guards the same way.
+    if isnothing(L.cache)
         L = cache_self(L, v)
     end
 

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -175,6 +175,8 @@ function update_coefficients(L::TensorProductOperator, u, p, t; kwargs...)
 end
 
 getops(L::TensorProductOperator) = L.ops
+getcache(L::TensorProductOperator) = L.cache
+adopt_cache(L::TensorProductOperator, cache, v) = cache_internals(update_cache(L, cache), v)
 
 # Copy method to avoid aliasing
 function Base.copy(L::TensorProductOperator)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -429,7 +429,9 @@ end
 @testset "AddedOperator cache sharing" begin
     v = rand(N)
     nbuf(cache) = length(unique(objectid, [b for b in cache if b !== nothing]))
-    nbuffers(L) = nbuf([b for op in L.ops for b in op.cache])
+    # `getcache`, not `op.cache`: a wrapper such as `ScaledOperator` has no cache field and
+    # reports the one belonging to the operator it wraps.
+    nbuffers(L) = nbuf([b for op in L.ops for b in SciMLOperators.getcache(op)])
 
     # Summands with interchangeable caches reuse one set of buffers.
     C1 = MatrixOperator(rand(N, N)) * MatrixOperator(rand(N, N))
@@ -476,6 +478,39 @@ end
     @test Lt.ops[2].cache[1] === Lt.ops[2].cache[5]
     @test nbuffers(Lt) == nbuf(cache_operator(T, vt).cache)   # two summands, one set
     @test mul!(zeros(8), Lt, vt) ≈ 2 * (T * vt)
+
+    # A wrapper holding no scratch of its own reports and replaces the cache of the operator
+    # it wraps. `A - B` lowers to `AddedOperator(A, -B)` with `-B` a `ScaledOperator`, so
+    # without this the commonest sum of all would share nothing.
+    @test nbuffers(cache_operator(2.0 * C1 + 3.0 * C2, v)) == 2   # 4 without forwarding
+    @test nbuffers(cache_operator(C1 - C2, v)) == 2               # 4 without forwarding
+    @test mul!(zeros(N), cache_operator(C1 - C2, v), v) ≈ C1 * v - C2 * v
+
+    let C = cache_operator(C1, v)
+        @test SciMLOperators.getcache(AdjointOperator(C)) === SciMLOperators.getcache(C)
+    end
+
+    # A tensor product whose factors are themselves composite shares as one with plain
+    # factors does. Its `cache_internals` used to re-run `cache_self` whenever any factor
+    # was uncached — the state `cache_operator` calls it in — discarding a donated cache.
+    Tc() = TensorProductOperator(
+        MatrixOperator(rand(2, 2)) * MatrixOperator(rand(2, 2)),
+        MatrixOperator(rand(4, 4)) * MatrixOperator(rand(4, 4))
+    )
+    T1, T2 = Tc(), Tc()
+    Lc = cache_operator(T1 + T2, vt)
+
+    @test Lc.ops[1].cache[1] === Lc.ops[2].cache[1]
+    @test mul!(zeros(8), Lc, vt) ≈ T1 * vt + T2 * vt
+
+    # Which slots alias each other is part of the layout, so a cache that folds two slots
+    # into one buffer is not interchangeable with one that keeps them apart, even when
+    # every slot matches in type and size.
+    let a = rand(4), b = rand(4)
+        @test SciMLOperators._slots_match((a, a), (b, b))
+        @test !SciMLOperators._slots_match((a, a), (rand(4), rand(4)))
+        @test !SciMLOperators._slots_match((a, b), (b, b))
+    end
 end
 
 @testset "ComposedOperator" begin

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -426,6 +426,58 @@ end
     end
 end
 
+@testset "AddedOperator cache sharing" begin
+    v = rand(N)
+    nbuf(cache) = length(unique(objectid, [b for b in cache if b !== nothing]))
+    nbuffers(L) = nbuf([b for op in L.ops for b in op.cache])
+
+    # Summands with interchangeable caches reuse one set of buffers.
+    C1 = MatrixOperator(rand(N, N)) * MatrixOperator(rand(N, N))
+    C2 = MatrixOperator(rand(N, N)) * MatrixOperator(rand(N, N))
+    L = cache_operator(C1 + C2, v)
+
+    @test nbuffers(L) == 2                          # 4 without sharing
+    @test L.ops[1].cache[1] !== L.ops[1].cache[2]   # slots live at once stay distinct
+    @test L * v ≈ C1 * v + C2 * v
+    @test mul!(zeros(N), L, v) ≈ C1 * v + C2 * v
+    @test (@inferred cache_operator(C1 + C2, v)) isa AddedOperator
+
+    # Setup allocates one cache, not one per summand: a summand takes an earlier one's
+    # buffers outright rather than allocating its own and discarding them. Without that,
+    # this grows by a full cache for every extra summand.
+    let n = 4096, vn = rand(n)
+        mk(M) = sum(
+            ntuple(
+                _ -> MatrixOperator(sprand(n, n, 1 / n)) * MatrixOperator(sprand(n, n, 1 / n)),
+                M
+            )
+        )
+        setup(M) = (Lm = mk(M); cache_operator(Lm, vn); @allocated cache_operator(Lm, vn))
+        @test setup(8) < 2 * setup(2)
+    end
+
+    # Caches whose slots differ in eltype are never interchanged, even though both
+    # summands are `ComposedOperator{ComplexF64}` of the same shape — `cache_self` takes
+    # each slot's eltype from the inner factor, not from the composite.
+    Ar = MatrixOperator(rand(N, N)) * MatrixOperator(rand(ComplexF64, N, N))
+    Ac = MatrixOperator(rand(ComplexF64, N, N)) * MatrixOperator(rand(N, N))
+    Lm = cache_operator(Ar + Ac, v)
+
+    @test eltype(Ar) === eltype(Ac) === ComplexF64
+    @test eltype(Lm.ops[1].cache[1]) === ComplexF64
+    @test eltype(Lm.ops[2].cache[1]) === Float64
+
+    # A square TensorProductOperator aliases cache slot 5 onto slot 1; sharing keeps it.
+    T = TensorProductOperator(MatrixOperator(rand(2, 2)), MatrixOperator(rand(4, 4)))
+    vt = rand(8)
+    Lt = cache_operator(T + T, vt)
+
+    @test Lt.ops[2].cache[1] === Lt.ops[1].cache[1]
+    @test Lt.ops[2].cache[1] === Lt.ops[2].cache[5]
+    @test nbuffers(Lt) == nbuf(cache_operator(T, vt).cache)   # two summands, one set
+    @test mul!(zeros(8), Lt, vt) ≈ 2 * (T * vt)
+end
+
 @testset "ComposedOperator" begin
     A = rand(N, N)
     B = rand(N, N)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

When caching an `AddedOperator`, we currently cache all the suboperators iteratively. However, this is suboptimal, as many of them can in principle share the same cache when possible.

In this PR I implement this cache sharing in the `AddedOperator`. Let's imagine I have the sum of `Composed + Tensor + Tensor + Composed + Matrix + Tensor`, many of them require some cache, but they could share the same cache. We can be sure they can share the same cache if

1. They have the same concrete type (e.g., two `ComposedOperator`s built from the same operand types)
2. The size of their cache is the same

The first is checked at compile time, and it also pins the element types for free. The second is checked at run time by comparing the operator's size and, recursively, its operands' sizes. Nothing has to declare its cache layout: `cache_self` stays the only description of what a cache is, so there is no second one that can drift out of sync with it.

## Benchmarks

This method allows to save a lot of memory, as also shown in this example

```julia
using SparseArrays
using SciMLOperators
using CairoMakie

function generate_op(N)
    M = 10
    sparsity = 1 / N

    A_list = ntuple(i -> MatrixOperator(sprand(N, N, sparsity)) * MatrixOperator(sprand(N, N, sparsity)), Val(M))

    op = SciMLOperators.AddedOperator(A_list)

    u = rand(N, N)
    return cache_operator(op, u)
    # return op
end

# %%

N_list = 4 .^ (2:7)
sizes_main = [Base.summarysize(generate_op(N)) for N in N_list]
sizes_pr = [Base.summarysize(generate_op(N)) for N in N_list]

# %%

fig = Figure()
ax = Axis(fig[1, 1], xlabel="N", ylabel="Size (MB)", xscale=log10, yscale=log10)

scatterlines!(ax, N_list, sizes_main ./ 1e6, label="main")
scatterlines!(ax, N_list, sizes_pr ./ 1e6, label="PR")

axislegend(ax; position = :lt)

fig
```

<img width="1406" height="1060" alt="image" src="https://github.com/user-attachments/assets/461095ed-3c6e-4981-875b-e977a8481edc" />

**Defining a new operator with a cache**

Nothing changes unless you opt in:

```julia
# take part in sharing
SciMLOperators.getcache(op::MyOperator) = op.cache

# optional: also skip allocating a cache that would be immediately discarded
SciMLOperators.adopt_cache(op::MyOperator, cache, v) =
    cache_internals(update_cache(op, cache), v)
```

The second line is for operators following the `cache_self`/`cache_internals` split; one that defines its own `cache_operator` should instead do whatever that does, with `cache` in place of the allocation. Both default to declining, so an operator defining neither behaves exactly as before.
