### PR TITLE
Integrate Adapt.jl support and add corresponding tests for array-backed operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,15 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 version = "1.18.0"
+authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [weakdeps]
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
@@ -21,10 +23,12 @@ SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
 [compat]
 Accessors = "0.1.42"
+Adapt = "4"
 ArrayInterface = "7.19"
 DocStringExtensions = "0.9.4"
 LinearAlgebra = "1.10"
 LoopVectorization = "0.12"
+SafeTestsets = "0.1.0"
 SparseArrays = "1.10"
 StaticArraysCore = "1"
 julia = "1.10"

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -11,6 +11,8 @@ import ArrayInterface
 # MacroTools dependency removed - using explicit method forwarding instead
 import Accessors: @reset
 
+using Adapt
+
 # overload
 import Base: show
 import Base: zero, one, oneunit
@@ -211,6 +213,7 @@ include("batch.jl")
 include("func.jl")
 include("tensor.jl")
 include("woperator.jl")
+include("adapt.jl")
 
 export
     IdentityOperator,

--- a/src/adapt.jl
+++ b/src/adapt.jl
@@ -1,0 +1,129 @@
+#
+# Adapt.jl integration for SciMLOperators
+#
+# Provides Adapt.adapt_structure methods for operators that contain array storage
+# or can transitively contain adapted operators.
+#
+
+# ============================================================================
+# Direct Array-Backed Operators (store arrays that need adaptation)
+# ============================================================================
+
+function Adapt.adapt_structure(to, L::MatrixOperator)
+    A_adapted = Adapt.adapt(to, L.A)
+    return MatrixOperator(
+        A_adapted,
+        L.update_func,
+        L.update_func!
+    )
+end
+
+function Adapt.adapt_structure(to, L::BatchedDiagonalOperator)
+    diag_adapted = Adapt.adapt(to, L.diag)
+    return BatchedDiagonalOperator(
+        diag_adapted,
+        L.update_func,
+        L.update_func!
+    )
+end
+
+function Adapt.adapt_structure(to, L::AffineOperator)
+    A_adapted = Adapt.adapt_structure(to, L.A)
+    B_adapted = Adapt.adapt_structure(to, L.B)
+    b_adapted = Adapt.adapt(to, L.b)
+    return AffineOperator(
+        A_adapted,
+        B_adapted,
+        b_adapted,
+        L.update_func,
+        L.update_func!
+    )
+end
+
+function Adapt.adapt_structure(to, L::FunctionOperator)
+    u_adapted = Adapt.adapt(to, L.u)
+    p_adapted = Adapt.adapt(to, L.p)
+    t_adapted = Adapt.adapt(to, L.t)
+    cache_adapted = Adapt.adapt(to, L.cache)
+
+    return set_cache(
+        set_t(
+            set_p(
+                set_u(L, u_adapted),
+                p_adapted
+            ),
+            t_adapted
+        ),
+        cache_adapted
+    )
+end
+
+# ============================================================================
+# Recursive Wrappers (can contain adapted operators or array caches)
+# ============================================================================
+
+function Adapt.adapt_structure(to, L::ScaledOperator)
+    L_adapted = Adapt.adapt_structure(to, L.L)
+    return ScaledOperator(L.λ, L_adapted)
+end
+
+function Adapt.adapt_structure(to, L::AddedOperator)
+    return AddedOperator(Adapt.adapt_structure(to, L.ops))
+end
+
+function Adapt.adapt_structure(to, L::ComposedOperator)
+    ops_adapted = Adapt.adapt_structure(to, L.ops)
+    cache_adapted = Adapt.adapt(to, L.cache)
+    return ComposedOperator(ops_adapted...; cache = cache_adapted)
+end
+
+function Adapt.adapt_structure(to, L::InvertedOperator)
+    L_adapted = Adapt.adapt_structure(to, L.L)
+    cache_adapted = Adapt.adapt(to, L.cache)
+    return InvertedOperator(L_adapted; cache = cache_adapted)
+end
+
+function Adapt.adapt_structure(to, L::InvertibleOperator)
+    L_adapted = Adapt.adapt_structure(to, L.L)
+    F_adapted = Adapt.adapt_structure(to, L.F)
+    return InvertibleOperator(L_adapted, F_adapted)
+end
+
+function Adapt.adapt_structure(to, L::BlockDiagonalOperator)
+    return BlockDiagonalOperator(Adapt.adapt_structure(to, L.ops))
+end
+
+function Adapt.adapt_structure(to, L::AdjointOperator)
+    L_adapted = Adapt.adapt_structure(to, L.L)
+    return AdjointOperator(L_adapted)
+end
+
+function Adapt.adapt_structure(to, L::TransposedOperator)
+    L_adapted = Adapt.adapt_structure(to, L.L)
+    return TransposedOperator(L_adapted)
+end
+
+function Adapt.adapt_structure(to, L::TensorProductOperator)
+    ops_adapted = Adapt.adapt_structure(to, L.ops)
+    cache_adapted = Adapt.adapt(to, L.cache)
+    return TensorProductOperator(ops_adapted...; cache = cache_adapted)
+end
+
+function Adapt.adapt_structure(to, L::TensorSumOperator)
+    ops_adapted = Adapt.adapt_structure(to, L.ops)
+    return TensorSumOperator(ops_adapted...)
+end
+
+# ============================================================================
+# Scalar Operators (no array storage, handled by generic Adapt fallback)
+# ============================================================================
+# ScalarOperator, AddedScalarOperator, ComposedScalarOperator, InvertedScalarOperator
+# do not store arrays, so they use Adapt's default struct adaptation which
+# recursively adapts non-array fields and leaves scalars unchanged.
+
+# ============================================================================
+# Explicitly Skipped (no arrays, no need for custom adaptation)
+# ============================================================================
+# IdentityOperator, NullOperator: store only integers/dimensions
+# These use Adapt's default struct adaptation (which is fine since no arrays).
+#

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"

--- a/test/adapt.jl
+++ b/test/adapt.jl
@@ -1,0 +1,243 @@
+using SciMLOperators, Adapt, Test, LinearAlgebra
+
+#
+# Adapt.jl Integration Tests
+#
+# Tests verify that Adapt.adapt_structure correctly handles array-backed operators
+# and recursively adapts nested/composite operators without GPU dependencies.
+#
+
+# ============================================================================
+# Custom Test Adaptor (no GPU required)
+# ============================================================================
+
+"""
+    CustomArray{T, N, AT <: AbstractArray{T, N}}
+
+Lightweight array wrapper used to prove Adapt changed storage types.
+"""
+struct CustomArray{T, N, AT <: AbstractArray{T, N}} <: AbstractArray{T, N}
+    data::AT
+end
+
+CustomArray(x::AT) where {T, N, AT <: AbstractArray{T, N}} = CustomArray{T, N, AT}(x)
+
+Base.size(x::CustomArray) = size(x.data)
+Base.getindex(x::CustomArray, I...) = getindex(x.data, I...)
+
+function Adapt.adapt_storage(::Type{CustomArray}, x::AbstractArray)
+    return CustomArray(x)
+end
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+"""
+    has_customarray(obj)
+
+Recursively detect whether any field in `obj` contains a `CustomArray`.
+"""
+function has_customarray(obj)
+    if obj isa CustomArray
+        return true
+    elseif obj isa Tuple || obj isa AbstractVector
+        return any(has_customarray, obj)
+    elseif obj isa SciMLOperators.AbstractSciMLOperator
+        return any(fname -> has_customarray(getfield(obj, fname)), fieldnames(typeof(obj)))
+    else
+        return false
+    end
+end
+
+# ============================================================================
+# Test Suite
+# ============================================================================
+
+@testset "Adapt.jl Support for SciMLOperators" begin
+
+    # ========================================================================
+    # Direct Array-Backed Operators
+    # ========================================================================
+
+    @testset "MatrixOperator" begin
+        L = MatrixOperator(rand(5, 5))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa MatrixOperator
+        @test L_adapted.A isa CustomArray
+        @test L_adapted.update_func === L.update_func
+        @test L_adapted.update_func! === L.update_func!
+    end
+
+    @testset "BatchedDiagonalOperator" begin
+        L = DiagonalOperator(rand(5, 3))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        # DiagonalOperator constructor returns BatchedDiagonalOperator.
+        @test L_adapted isa SciMLOperators.BatchedDiagonalOperator
+        @test L_adapted.diag isa CustomArray
+        @test L_adapted.update_func === L.update_func
+        @test L_adapted.update_func! === L.update_func!
+    end
+
+    @testset "AffineOperator" begin
+        A = MatrixOperator(rand(5, 5))
+        B = MatrixOperator(rand(5, 5))
+        L = AffineOperator(A, B, rand(5))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa AffineOperator
+        @test L_adapted.A isa MatrixOperator
+        @test L_adapted.B isa MatrixOperator
+        @test L_adapted.A.A isa CustomArray
+        @test L_adapted.B.A isa CustomArray
+        @test L_adapted.b isa CustomArray
+    end
+
+    @testset "FunctionOperator" begin
+        input = rand(5)
+        output = rand(5)
+        op = (v, u, p, t) -> 0.5 .* v
+        L = FunctionOperator(op, input, output; u = rand(3), p = rand(4), t = 0.0)
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa FunctionOperator
+        @test L_adapted.u isa CustomArray
+        @test L_adapted.p isa CustomArray
+    end
+
+    # ========================================================================
+    # Recursive Wrapper Operators
+    # ========================================================================
+
+    @testset "ScaledOperator" begin
+        L = 2.5 * MatrixOperator(rand(5, 5))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.ScaledOperator
+        @test L_adapted.L isa MatrixOperator
+        @test L_adapted.L.A isa CustomArray
+    end
+
+    @testset "AddedOperator" begin
+        L = MatrixOperator(rand(5, 5)) + DiagonalOperator(rand(5, 3))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.AddedOperator
+        @test L_adapted.ops[1] isa MatrixOperator
+        @test L_adapted.ops[2] isa SciMLOperators.BatchedDiagonalOperator
+        @test L_adapted.ops[1].A isa CustomArray
+        @test L_adapted.ops[2].diag isa CustomArray
+    end
+
+    @testset "ComposedOperator" begin
+        L = MatrixOperator(rand(5, 5)) * MatrixOperator(rand(5, 5))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.ComposedOperator
+        @test L_adapted.ops[1].A isa CustomArray
+        @test L_adapted.ops[2].A isa CustomArray
+    end
+
+    @testset "InvertedOperator" begin
+        L = inv(MatrixOperator(rand(5, 5)))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.InvertedOperator
+        @test L_adapted.L.A isa CustomArray
+    end
+
+    @testset "InvertibleOperator" begin
+        L = lu(MatrixOperator(rand(5, 5)))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.InvertibleOperator
+        @test L_adapted.L.A isa CustomArray
+    end
+
+    @testset "BlockDiagonalOperator" begin
+        L = BlockDiagonalOperator(MatrixOperator(rand(3, 3)), MatrixOperator(rand(2, 2)))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.BlockDiagonalOperator
+        @test L_adapted.ops[1].A isa CustomArray
+        @test L_adapted.ops[2].A isa CustomArray
+    end
+
+    @testset "AdjointOperator/TransposedOperator" begin
+        L_adj = SciMLOperators.AdjointOperator(MatrixOperator(rand(5, 5)))
+        L_t = SciMLOperators.TransposedOperator(MatrixOperator(rand(5, 5)))
+
+        L_adj_adapted = Adapt.adapt_structure(CustomArray, L_adj)
+        L_t_adapted = Adapt.adapt_structure(CustomArray, L_t)
+
+        @test L_adj_adapted isa SciMLOperators.AdjointOperator
+        @test L_adj_adapted.L isa MatrixOperator
+        @test L_adj_adapted.L.A isa CustomArray
+
+        @test L_t_adapted isa SciMLOperators.TransposedOperator
+        @test L_t_adapted.L isa MatrixOperator
+        @test L_t_adapted.L.A isa CustomArray
+    end
+
+    @testset "TensorProductOperator" begin
+        import SciMLOperators.⊗
+        L = MatrixOperator(rand(3, 3)) ⊗ MatrixOperator(rand(2, 2))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.TensorProductOperator
+        @test L_adapted.ops[1].A isa CustomArray
+        @test L_adapted.ops[2].A isa CustomArray
+    end
+
+    @testset "TensorSumOperator" begin
+        L = kronsum(MatrixOperator(rand(3, 3)), MatrixOperator(rand(2, 2)))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.TensorSumOperator
+        @test L_adapted.ops[1].A isa CustomArray
+        @test L_adapted.ops[2].A isa CustomArray
+    end
+
+    # ========================================================================
+    # Complex Nested Structures
+    # ========================================================================
+
+    @testset "Deeply Nested Composite Operator" begin
+        L_nested = (MatrixOperator(rand(5, 5)) + DiagonalOperator(rand(5, 3))) * MatrixOperator(rand(5, 5))
+        L_adapted = Adapt.adapt_structure(CustomArray, L_nested)
+
+        @test L_adapted isa SciMLOperators.ComposedOperator
+        @test L_adapted.ops[1] isa SciMLOperators.AddedOperator
+        @test has_customarray(L_adapted)
+    end
+
+    @testset "Affine with Composed Operators" begin
+        L = 2.0 * AffineOperator(MatrixOperator(rand(5, 5)), MatrixOperator(rand(5, 5)), rand(5))
+        L_adapted = Adapt.adapt_structure(CustomArray, L)
+
+        @test L_adapted isa SciMLOperators.ScaledOperator
+        @test L_adapted.L isa SciMLOperators.AffineOperator
+        @test L_adapted.L.A.A isa CustomArray
+        @test L_adapted.L.B.A isa CustomArray
+        @test L_adapted.L.b isa CustomArray
+    end
+
+    # ========================================================================
+    # Array-Free Operators
+    # ========================================================================
+
+    @testset "Array-Free Operators" begin
+        L_id = Adapt.adapt_structure(CustomArray, IdentityOperator(5))
+        L_null = Adapt.adapt_structure(CustomArray, NullOperator(5, 5))
+
+        @test L_id isa SciMLOperators.IdentityOperator
+        @test L_null isa SciMLOperators.NullOperator
+        @test !has_customarray(L_id)
+        @test !has_customarray(L_null)
+    end
+
+end
+
+println("All Adapt tests passed!")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,9 @@ end
             @time @safetestset "Copy methods" begin
                 include("copy.jl")
             end
+            @time @safetestset "Adapt.jl" begin
+                include("adapt.jl")
+            end
         elseif GROUP == "All" || GROUP == "Downstream"
             activate_downstream_env()
             @time @safetestset "AllocCheck" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

- Add `Adapt.adapt_structure` methods for array-backed and recursive SciMLOperators.
- Keep array-free operators unchanged.
- Add focused Adapt tests using CustomArray wrapping via `Adapt.adapt_structure(CustomArray, L)`.

