### PR TITLE
sparse conversion of BlockDiagonalOperator, TensorSumOperator and NullOperator

### DIFF
--- a/ext/SciMLOperatorsSparseArraysExt.jl
+++ b/ext/SciMLOperatorsSparseArraysExt.jl
@@ -14,5 +14,11 @@ SparseArrays.sparse(L::SciMLOperators.IdentityOperator) = sparse(LinearAlgebra.I
 function SparseArrays.sparse(L::SciMLOperators.TensorProductOperator)
     return LinearAlgebra.kron(sparse.(L.ops)...)
 end
+function SparseArrays.sparse(L::SciMLOperators.BlockDiagonalOperator)
+    return SparseArrays.blockdiag(sparse.(L.ops)...)
+end
+function SparseArrays.sparse(L::SciMLOperators.NullOperator)
+    return SparseArrays.spzeros(eltype(L), size(L))
+end
 
 end

--- a/ext/SciMLOperatorsSparseArraysExt.jl
+++ b/ext/SciMLOperatorsSparseArraysExt.jl
@@ -20,5 +20,6 @@ end
 function SparseArrays.sparse(L::SciMLOperators.NullOperator)
     return SparseArrays.spzeros(eltype(L), size(L))
 end
+SparseArrays.sparse(L::SciMLOperators.TensorSumOperator) = sum(sparse, L.products)
 
 end

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -806,4 +806,9 @@ end
     opB_sparse = sparse(opB)
     @test opB_sparse ≈ B
     @test issparse(opB_sparse)
+
+    L = BlockDiagonalOperator(opA, opB, NullOperator(2, 3))
+    sL = sparse(L)
+    @test issparse(sL)
+    @test sL ≈ Matrix(L)
 end

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -811,4 +811,10 @@ end
     sL = sparse(L)
     @test issparse(sL)
     @test sL ≈ Matrix(L)
+
+    # TensorSumOperator
+    Lkronsum = kronsum(opB, opB)
+    sLkronsum = sparse(Lkronsum)
+    @test issparse(sLkronsum)
+    @test sLkronsum ≈ Matrix(Lkronsum)
 end


### PR DESCRIPTION
Recently, BlockDiagonalOperator and TensorSumOperator were introduced, see #365 #366. This PR adds support for converting these and NullOperator to sparse matrices.