### PR TITLE
Centralize CI on SciML/.github reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,12 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,52 +7,21 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: "Downstream ${{ matrix.package.repo }}/${{ matrix.package.group }}"
     strategy:
+      fail-fast: false
       matrix:
         julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: SciMLBase.jl, group: InterfaceII}
           - {user: SciML, repo: DiffEqBase.jl, group: InterfaceII}
           - {user: SciML, repo: LinearSolve.jl, group: InterfaceII}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII}
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      julia-arch: "x64"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.1 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI jobs to the centralized reusable workflows in `SciML/.github`, pinned at `@v1`, with `secrets: "inherit"` on every caller.

## Converted (inline -> central)
- **FormatCheck.yml** (Runic): inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`. Preserved exactly: `if: false` (the job was already disabled), `julia-version: "1.10"`, `skip: "Pkg,TOML"`, `allow-reresolve: false`.
- **Downstream.yml** (IntegrationTest): inline job -> matrix of `downstream.yml@v1` callers, preserving the package+group list (SciMLBase.jl, DiffEqBase.jl, LinearSolve.jl, OrdinaryDiffEq.jl — all `group: InterfaceII`, `julia-version: 1`, `arch: x64`).

## Already central (unchanged)
- **Tests.yml** — already `tests.yml@v1` with the exact `version × group` matrix and `secrets: inherit`.
- **Documentation.yml** — already `documentation.yml@v1` with `secrets: inherit`.

## Other changes
- **dependabot.yml**: removed the `crate-ci/typos` version-update ignore (no longer pinned here since typos runs via the central caller). `github-actions` (weekly, `/`) and `julia` (daily, dirs `/`, `/docs`, `/test`, group all-julia-packages `["*"]`) blocks preserved.

## Checks
- `typos .` -> exit 0 (already clean). **0 typos fixed.**
- Runic `--inplace .` -> no changes (Julia sources already Runic-clean; repo ran Runic inline). **No formatting applied.**
- All changed YAML validated with `yaml.safe_load`.

## Note on branch protection
Check names change (e.g. the Runic check now runs as a reusable-workflow job, downstream jobs are now `Downstream Tests - InterfaceII`, etc.). Any required-status-check names in branch protection will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)