### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   downgrade:
-    if: false
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:

--- a/Project.toml
+++ b/Project.toml
@@ -22,11 +22,11 @@ SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
 [compat]
 Accessors = "0.1.42"
-Adapt = "4"
+Adapt = "4.5.2"
 ArrayInterface = "7.19"
 DocStringExtensions = "0.9.4"
 LinearAlgebra = "1.10"
 LoopVectorization = "0.12"
 SparseArrays = "1.10"
-StaticArraysCore = "1"
+StaticArraysCore = "1.4.4"
 julia = "1.10"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow with `allow_reresolve: false` (genuine test-at-floor: tests run at the minimal/downgraded versions). Raises declared-dep `[compat]` lower bounds: `Adapt = "4.5.2";StaticArraysCore = "1.4.4";`Adapt = "4.5.2";StaticArraysCore = "1.4.4";

Verified locally on Julia 1.10 in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with 0 re-resolve. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)