### PR TITLE
WOperator{!IIP}: materialize MatrixOperator mass matrix in convert(AbstractMatrix, W)

### DIFF
--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -123,8 +123,12 @@ end
 
 function Base.convert(::Type{AbstractMatrix}, W::WOperator{IIP}) where {IIP}
     if !IIP
-        # Allocating
-        W._concrete_form = -W.mass_matrix / W.gamma + convert(AbstractMatrix, W.J)
+        # Mirror the constructor: materialize a MatrixOperator mass matrix so the
+        # result type matches `_concrete_form` (otherwise this becomes an
+        # AddedOperator and the assignment back into the Matrix-typed slot fails).
+        mm = W.mass_matrix isa MatrixOperator ?
+            convert(AbstractMatrix, W.mass_matrix) : W.mass_matrix
+        W._concrete_form = -mm / W.gamma + convert(AbstractMatrix, W.J)
     end
     return W._concrete_form
 end

--- a/test/shared/WOperator.jl
+++ b/test/shared/WOperator.jl
@@ -27,4 +27,28 @@ Random.seed!(0)
     W_scalar2 = WOperator{false}(I, 0.5, ScalarOperator(2.0), 1.0)
     @test_deprecated update_coefficients!(W_scalar2; dtgamma = 0.25)
     @test convert(Number, W_scalar2) ≈ 2.0 - 1.0 / 0.25
+
+    # OOP WOperator with a MatrixOperator mass matrix: convert(AbstractMatrix, W)
+    # must materialize the mass matrix so the result fits in the
+    # Matrix-typed _concrete_form slot (issue #396).
+    n = 3
+    mm_data = randn(n, n)
+    update_mm!(A, u, p, t) = (A[1, 1] = cos(t); A[2, 2] = u[1]; A)
+    update_mm(A, u, p, t) = (B = copy(A); update_mm!(B, u, p, t); B)
+    mm_op = MatrixOperator(
+        copy(mm_data); update_func = update_mm, update_func! = update_mm!,
+    )
+    J_mm = randn(n, n)
+    u_mm = randn(n)
+    gamma_mm = 0.1
+    W_mm = WOperator{false}(mm_op, gamma_mm, J_mm, u_mm)
+    W_ref = -convert(AbstractMatrix, mm_op) / gamma_mm + J_mm
+    @test convert(AbstractMatrix, W_mm) ≈ W_ref
+    # Re-materialization after update_coefficients!
+    update_coefficients!(W_mm, randn(n), nothing, 1.5; gamma = 0.2)
+    W_ref2 = -convert(AbstractMatrix, W_mm.mass_matrix) / 0.2 + J_mm
+    @test convert(AbstractMatrix, W_mm) ≈ W_ref2
+    # And `\` works end-to-end
+    b = randn(n)
+    @test W_mm \ b ≈ convert(AbstractMatrix, W_mm) \ b
 end


### PR DESCRIPTION
Fixes #396.

`Base.convert(::Type{AbstractMatrix}, W::WOperator{!IIP})` re-materializes `_concrete_form` from `W.mass_matrix` and `W.J`, but only `W.J` was being passed through `convert(AbstractMatrix, ...)`. When `W.mass_matrix` is a `MatrixOperator`, `-W.mass_matrix / W.gamma` stays an `AbstractSciMLOperator` (`ScaledOperator`), then `+ convert(AbstractMatrix, W.J)` becomes an `AddedOperator`, which cannot be assigned back to the `Matrix`-typed `_concrete_form` slot. Result: a `MethodError`.

The constructor at `src/woperator.jl:62-67` already materializes the mass matrix:
```julia
mm = mass_matrix isa MatrixOperator ?
    convert(AbstractMatrix, mass_matrix) : mass_matrix
_concrete_form = -mm / gamma + AJ
```
This PR mirrors that same conversion in the refresh path. No other paths change.

Added a regression test under `test/shared/WOperator.jl` that:
- Builds an OOP `WOperator` with a `MatrixOperator` mass matrix
- Calls `convert(AbstractMatrix, W)` and verifies the value matches the reference
- Re-materializes after `update_coefficients!(W, u, p, t; gamma)`
- Verifies `W \ b` works end-to-end

## Why it matters

This is the proximate cause of OrdinaryDiffEq.jl's OOP `NLNewton` "Dependent Mass Matrix Tests" failing on master — any user combining `iip=false` + `mass_matrix = MatrixOperator(...)` + an implicit solver hits this. With this fix in, the OrdinaryDiffEq side can drop the `error("Non-concrete Jacobian not yet supported by out-of-place Newton solve.")` for the SciMLOperator-mass-matrix path. Follow-up PR there will bump the `SciMLOperators` compat floor once this is tagged.

## Test plan
- [x] New `test/shared/WOperator.jl` regression covers the MatrixOperator + OOP + `\` path
- [x] Existing WOperator tests still pass