### PR TITLE
Document scalar operator interface type

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -2,6 +2,7 @@
 
 ```@docs
 SciMLOperators.AbstractSciMLOperator
+SciMLOperators.AbstractSciMLScalarOperator
 ```
 
 ## Interface API Reference


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Add `AbstractSciMLScalarOperator` to the interface docs alongside `AbstractSciMLOperator`.

## Verification
- Targeted public-name scan showed all public names present under docs.
- Docs build completed successfully and rendered the new entry.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic_env -m Runic --check .` exited 0.
- `git diff --check` exited 0.