### PR TITLE
Add `ArrayInterface.issingular` for `IdentityOperator` and `ScalarOperator`

### DIFF
--- a/src/basic.jl
+++ b/src/basic.jl
@@ -31,6 +31,7 @@ LinearAlgebra.opnorm(::IdentityOperator, p::Real = 2) = true
 for pred in (:issymmetric, :ishermitian, :isposdef)
     @eval LinearAlgebra.$pred(::IdentityOperator) = true
 end
+ArrayInterface.issingular(::IdentityOperator) = false
 
 getops(::IdentityOperator) = ()
 isconstant(::IdentityOperator) = true

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -231,6 +231,7 @@ getops(α::ScalarOperator) = (α.val,)
 isconstant(α::ScalarOperator) = update_func_isconstant(α.update_func)
 has_ldiv(α::ScalarOperator) = !iszero(α.val)
 has_ldiv!(α::ScalarOperator) = has_ldiv(α)
+ArrayInterface.issingular(α::ScalarOperator) = iszero(α.val)
 
 function update_coefficients!(L::ScalarOperator, u, p, t; kwargs...)
     L.val = L.update_func(L.val, u, p, t; kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
@@ -12,6 +13,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Adapt = "4.5.2"
+ArrayInterface = "7.19"
 FFTW = "1.10.0"
 LoopVectorization = "0.12"
 SafeTestsets = "0.1.0"

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,4 +1,5 @@
 using SciMLOperators, LinearAlgebra, SparseArrays
+using ArrayInterface
 using Random
 
 using SciMLOperators: IdentityOperator,
@@ -39,6 +40,7 @@ K = 12
     @test size(Id) == (N, N)
     @test Id' isa IdentityOperator
     @test isconstant(Id)
+    @test !ArrayInterface.issingular(Id)
     @test_throws MethodError resize!(Id, N)
 
     for op in (*, \)

--- a/test/scalar.jl
+++ b/test/scalar.jl
@@ -8,6 +8,7 @@ using SciMLOperators: AbstractSciMLScalarOperator,
     ScaledOperator
 
 using LinearAlgebra, Random, Test
+using ArrayInterface
 
 Random.seed!(0)
 N = 8
@@ -30,6 +31,8 @@ K = 12
 
     @test size(α) == ()
     @test isconstant(α)
+    @test !ArrayInterface.issingular(α)
+    @test ArrayInterface.issingular(ScalarOperator(0.0))
 
     # Original lmul!/rmul! tests
     v = copy(u)


### PR DESCRIPTION
`IdentityOperator` and `ScalarOperator` cannot be used as `f.mass_matrix` in OrdinaryDiffEq today because `ArrayInterface.issingular` is not defined on them, so the DAE check at the top of `solve` throws before the solver even starts. Repro on master: SciML/OrdinaryDiffEq.jl#3814.

Adds:

```julia
ArrayInterface.issingular(::IdentityOperator) = false
ArrayInterface.issingular(op::ScalarOperator) = iszero(op.val)
```

Alongside the existing `ArrayInterface.issingular(::MatrixOperator)` in `matrix.jl:278`.

Tests exercise both methods in `test/basic.jl` and `test/scalar.jl`.

Note: this fixes only the `issingular` blocker. A separate follow-up in OrdinaryDiffEqCore is needed for `get_differential_vars` (`lib/OrdinaryDiffEqCore/src/misc_utils.jl:143`), which calls `all(!iszero, mass_matrix)` and needs an `IdentityOperator`/`ScalarOperator`-aware branch.