### PR TITLE
Document public operator interfaces

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -30,6 +30,7 @@ has_mul
 has_mul!
 has_ldiv
 has_ldiv!
+SciMLOperators.has_concretization
 ```
 
 ## Note About Affine Operators

--- a/docs/src/premade_operators.md
+++ b/docs/src/premade_operators.md
@@ -11,7 +11,12 @@ DiagonalOperator
 AffineOperator
 AddVector
 FunctionOperator
+BlockDiagonalOperator
 TensorProductOperator
+TensorSumOperator
+kronsum
+WOperator
+SciMLOperators.StaticWOperator
 ```
 
 ## Lazy Scalar Operator Combination

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -47,7 +47,7 @@ where `L[v]` is the operator application of ``L`` on the vector ``v``.
 
 ## Interface
 
-An `AbstractSciMLOperator` can be called  like a function in the following ways:
+An `AbstractSciMLOperator` can be called like a function in the following ways:
 
   - `L(v, u, p, t)` - Out-of-place application where `v` is the action vector and `u` is the update vector
   - `L(w, v, u, p, t)` - In-place application where `w` is the destination, `v` is the action vector, and `u` is the update vector
@@ -64,6 +64,43 @@ An `AbstractSciMLOperator` behaves like a matrix in these methods.
 Allocation-free methods, suffixed with a `!` often need cache arrays.
 To precache an `AbstractSciMLOperator`, call the function
 `L = cache_operator(L, input_vector)`.
+
+## Required Interface For Subtypes
+
+A concrete subtype must define `Base.size(L)` and one of the following
+application paths:
+
+  - `Base.:*(L, v)` for out-of-place matrix-like application.
+  - `LinearAlgebra.mul!(w, L, v)` and, when `has_mul!(L)` is `true`,
+    `LinearAlgebra.mul!(w, L, v, α, β)` for in-place application.
+  - `Base.convert(AbstractMatrix, L)` when `isconvertible(L)` is `true`.
+
+If the operator state depends on `(u, p, t)` or accepted keyword arguments,
+the subtype must implement `update_coefficients` for out-of-place state
+updates or `update_coefficients!` for in-place state updates. Composite
+operators assume these update methods may be called recursively on every
+operator returned by `getops(L)`.
+
+Subtypes that need preallocated work arrays for allocation-free application
+must implement `cache_self(L, v)` for their own caches, `cache_internals(L, v)`
+for child-operator caches, or both. `cache_operator(L, v)` calls these hooks
+and downstream solvers may call it before repeated `mul!` evaluations.
+
+## Trait Rules
+
+Trait functions such as `isconstant`, `islinear`, `isconvertible`,
+`has_concretization`, `has_mul`, `has_mul!`, `has_ldiv`, and `has_ldiv!`
+are part of the public operator interface. A trait returning `true` is a
+promise that the corresponding operation is valid for inputs with compatible
+sizes. For example, `has_mul!(L)` means `mul!(w, L, v)` is available, and
+`has_concretization(L)` means either `convert(AbstractMatrix, L)` or
+`convert(Number, L)` can materialize the operator state without changing its
+mathematical action.
+
+`isconstant(L)` means repeated calls to `update_coefficients[!]` are not
+required to keep `L` current. `islinear(L)` means the action is linear in
+the vector being multiplied; state dependence on `(u, p, t)` is still allowed
+for a linear operator.
 
 ## Overloaded Actions
 

--- a/src/block.jl
+++ b/src/block.jl
@@ -1,7 +1,38 @@
 """
 $(TYPEDEF)
 
-Lazy block diagonal operator.
+Lazy block diagonal operator built from `AbstractSciMLOperator` blocks.
+
+# Arguments
+
+  - `ops`: Operators or matrices to place on the block diagonal. Matrix
+    arguments are wrapped in `MatrixOperator`.
+
+# Fields
+
+$(FIELDS)
+
+# Interface Rules
+
+`BlockDiagonalOperator` applies each block to the corresponding slice of the
+input and concatenates the results. Its size is the sum of block row and
+column sizes. `update_coefficients[!]`, caching, and trait queries are
+forwarded to each block, so a block diagonal operator has concretization,
+in-place multiplication, or adjoint support only when the required component
+operators do.
+
+# Examples
+
+```julia
+using LinearAlgebra, SciMLOperators
+
+A = MatrixOperator([1.0 2.0; 3.0 4.0])
+B = MatrixOperator(Diagonal([5.0, 6.0, 7.0]))
+L = BlockDiagonalOperator(A, B)
+
+v = ones(5)
+L * v == Matrix(L) * v
+```
 """
 struct BlockDiagonalOperator{
         T,

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -200,6 +200,41 @@ factorize(L::TensorProductOperator) = TensorProductOperator(map(factorize, L.ops
 $(TYPEDEF)
 
 Lazy Kronecker sum operator.
+
+# Arguments
+
+  - `outer`: A square matrix or `AbstractSciMLOperator` representing the first
+    term in `outer ⊗ I`.
+  - `inner`: A square matrix or `AbstractSciMLOperator` representing the second
+    term in `I ⊗ inner`.
+
+# Fields
+
+$(FIELDS)
+
+# Interface Rules
+
+`TensorSumOperator(outer, inner)` represents `outer ⊗ I + I ⊗ inner` without
+eagerly forming the Kronecker products. Both input operators must be square.
+The operator forwards state updates to `outer` and `inner`, and its cached
+application stores the two tensor-product terms needed by `mul!`.
+
+`isconvertible(::TensorSumOperator)` is `false` because eager fusion is not the
+default algebra path, but `has_concretization(L)` is `true` when both operands
+can be materialized.
+
+# Examples
+
+```julia
+using LinearAlgebra, SciMLOperators
+
+A = MatrixOperator([1.0 2.0; 3.0 4.0])
+B = MatrixOperator(Diagonal([5.0, 6.0, 7.0]))
+L = TensorSumOperator(A, B)
+
+v = ones(6)
+L * v == Matrix(L) * v
+```
 """
 struct TensorSumOperator{T, O, P} <: AbstractSciMLOperator{T}
     ops::O
@@ -236,6 +271,35 @@ end
 $SIGNATURES
 
 Construct the lazy Kronecker sum `A ⊗ I + I ⊗ B`.
+
+# Arguments
+
+  - `A`: A square matrix or `AbstractSciMLOperator`.
+  - `B`: A square matrix or `AbstractSciMLOperator`.
+
+# Returns
+
+A `TensorSumOperator` whose action is equivalent to
+`kron(A, I(size(B, 1))) + kron(I(size(A, 1)), B)`.
+
+# Interface Rules
+
+Both inputs must be square. Matrix inputs are wrapped in `MatrixOperator` so
+the returned object participates in the `AbstractSciMLOperator` update,
+caching, multiplication, and trait interfaces.
+
+# Examples
+
+```julia
+using LinearAlgebra, SciMLOperators
+
+A = [1.0 2.0; 3.0 4.0]
+B = Diagonal([5.0, 6.0, 7.0])
+L = kronsum(A, B)
+
+v = ones(6)
+L * v == Matrix(L) * v
+```
 """
 kronsum(A::Union{AbstractMatrix, AbstractSciMLOperator}, B::Union{AbstractMatrix, AbstractSciMLOperator}) = TensorSumOperator(A, B)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,5 +80,44 @@ isnothingfunc(f) = false
 _unwrap_val(x) = x
 _unwrap_val(::Val{X}) where {X} = X
 
+"""
+$SIGNATURES
+
+Return whether `L` can be materialized into a concrete scalar or matrix
+representation for fallback operations.
+
+# Arguments
+
+  - `L`: An operator-like object.
+
+# Returns
+
+`true` when `concretize(L)` is expected to succeed by calling
+`convert(AbstractMatrix, L)` or `convert(Number, L)`, and `false` otherwise.
+
+# Interface Rules
+
+Subtypes of `AbstractSciMLOperator` should define `has_concretization(L)` as
+`true` only when their current state can be materialized without changing the
+operator action. Composite operators should return `true` only when every
+component needed for the materialization also has concretization.
+
+This trait is intentionally separate from `isconvertible(L)`: an operator can
+have a correct concrete representation but avoid cheap eager fusion in generic
+algebra paths.
+
+# Examples
+
+```julia
+using SciMLOperators
+
+A = MatrixOperator([1.0 2.0; 3.0 4.0])
+has_concretization(A) # true
+
+F = FunctionOperator((y, x, u, p, t) -> copyto!(y, x), zeros(2), zeros(2);
+    isinplace = true, T = Float64, islinear = true)
+has_concretization(F) # false
+```
+"""
 has_concretization(::AbstractSciMLOperator) = false
 has_concretization(::Union{AbstractMatrix, UniformScaling, Factorization, Number}) = true

--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -1,5 +1,36 @@
 abstract type AbstractWOperator{T} <: AbstractSciMLOperator{T} end
 
+"""
+$(TYPEDEF)
+
+Small dense factorization helper for repeated solves with a fixed `W` matrix.
+
+# Arguments
+
+  - `W`: Concrete square matrix to solve against.
+  - `callinv`: Whether very small matrices may store `inv(W)` for direct
+    multiplication during `\\`.
+
+# Fields
+
+$(FIELDS)
+
+# Interface Rules
+
+`StaticWOperator` is a specialized helper for solver internals that need a
+fixed W-operator solve. It supports `Wstatic \\ v`; it does not participate in
+coefficient updates and should be reconstructed when the underlying matrix
+changes.
+
+# Examples
+
+```julia
+using SciMLOperators
+
+W = StaticWOperator([2.0 0.0; 0.0 4.0])
+W \\ [2.0, 8.0]
+```
+"""
 struct StaticWOperator{isinv, T, F} <: AbstractWOperator{T}
     W::T
     F::F
@@ -25,7 +56,9 @@ end
 Base.:\(W::StaticWOperator{isinv}, v::AbstractArray) where {isinv} = isinv ? W.W * v : W.F \ v
 
 """
-    WOperator(mass_matrix,gamma,J)
+$TYPEDEF
+
+    WOperator{IIP}(mass_matrix, gamma, J, u[, jacvec])
 
 A linear operator that represents the W matrix of an ODEProblem, defined as
 
@@ -33,11 +66,46 @@ A linear operator that represents the W matrix of an ODEProblem, defined as
 W = \\frac{1}{\\gamma}MM - J
 ```
 
-where `MM` is the mass matrix (a regular `AbstractMatrix` or a `UniformScaling`),
-`γ` is a real number, and `J` is the Jacobian operator (must be a `AbstractSciMLOperator`).
+where `MM` is the mass matrix, `γ` is a scalar, and `J` is the Jacobian
+operator.
 
-`WOperator` supports lazy `*` and `mul!` operations, the latter utilizing an
-internal cache (can be specified in the constructor; default to regular `Vector`).
+# Arguments
+
+  - `mass_matrix`: A matrix-like object, `UniformScaling`, or `MatrixOperator`
+    representing `MM`.
+  - `gamma`: Scalar coefficient in the W-operator definition.
+  - `J`: Jacobian represented as a number, matrix, or `AbstractSciMLOperator`.
+  - `u`: Prototype state used to allocate the internal multiplication cache.
+  - `jacvec`: Optional operator used for Jacobian-vector products in `mul!`.
+
+# Fields
+
+$(FIELDS)
+
+# Interface Rules
+
+`WOperator` is part of the public solver-developer interface used by implicit
+ODE solvers. It supports matrix-like `*`, `\\`, `mul!`, indexing, sizing, and
+concretization. Calling `update_coefficients!(W, u, p, t; gamma)` updates the
+Jacobian, mass matrix, optional Jacobian-vector operator, and stored `gamma`.
+Omitting `(u, p, t)` leaves those operators unchanged and only updates `gamma`
+when it is supplied.
+
+`IIP` controls whether conversion reuses the internally stored concrete form
+as an in-place operator. The public contract is the mathematical action of
+`W`; downstream code should not depend on `_func_cache` or `_concrete_form`.
+
+# Examples
+
+```julia
+using LinearAlgebra, SciMLOperators
+
+J = MatrixOperator([1.0 2.0; 3.0 4.0])
+W = WOperator{true}(I, 0.5, J, zeros(2))
+
+v = [1.0, 2.0]
+W * v == (Matrix(W) * v)
+```
 """
 mutable struct WOperator{
         IIP, T,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -42,3 +42,37 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = qualified_access_ignore),
     ),
 )
+
+@testset "Public API documentation coverage" begin
+    mod = SciMLOperators
+    doc_bindings = Set(keys(Base.Docs.meta(mod)))
+    public_names = setdiff(Symbol.(names(mod; all = false, imported = false)), (:SciMLOperators,))
+
+    missing_docstrings = Symbol[]
+    for name in public_names
+        binding = Base.Docs.Binding(mod, name)
+        binding in doc_bindings || push!(missing_docstrings, name)
+    end
+    @test isempty(missing_docstrings)
+
+    docs_src = joinpath(pkgdir(mod), "docs", "src")
+    docs_text = IOBuffer()
+    for (root, _, files) in walkdir(docs_src)
+        for file in files
+            endswith(file, ".md") || continue
+            write(docs_text, read(joinpath(root, file), String))
+            write(docs_text, '\n')
+        end
+    end
+    rendered_docs = String(take!(docs_text))
+    rendered_lines = Set(strip.(split(rendered_docs, '\n')))
+
+    missing_rendered_docs = Symbol[]
+    for name in public_names
+        name_text = String(name)
+        rendered = occursin("SciMLOperators.$name_text", rendered_docs) ||
+            name_text in rendered_lines
+        rendered || push!(missing_rendered_docs, name)
+    end
+    @test isempty(missing_rendered_docs)
+end


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- expands the `AbstractSciMLOperator` interface docstring with subtype requirements, cache hooks, and trait rules
- adds source-site SciMLStyle docstrings for `BlockDiagonalOperator`, `TensorSumOperator`, `kronsum`, `WOperator`, `StaticWOperator`, and `has_concretization`
- renders the missing public/exported operator APIs in the manual
- adds QA coverage requiring every public/exported name to have both a docstring and a rendered docs entry

## Validation
- `git diff --check`
- Runic formatting on touched Julia files
- direct public docs coverage script: `missing docstrings: Symbol[]`, `missing rendered docs: Symbol[]`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'` passed: QA 15 pass / 1 existing broken, public docs coverage 2/2\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` passed; remaining warnings are existing non-public/internal docstrings not included in the manual plus a GitHub 429 linkcheck for ColPrac\n