### PR TITLE
Make isconvertible honest for matrix-free WOperator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.24.0"
+version = "1.24.1"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 
 [deps]

--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -204,6 +204,12 @@ function Base.convert(::Type{Number}, W::WOperator)
     W._concrete_form = -W.mass_matrix / W.gamma + convert(Number, W.J)
     return W._concrete_form
 end
+# `convert(AbstractMatrix, W)` fuses `-M/γ` with `convert(AbstractMatrix, W.J)`, so `W` is
+# convertible exactly when both its mass matrix `M` and its Jacobian `W.J` are. A matrix-free
+# `W.J` (e.g. a Jacobian-vector-product operator) — or a matrix-free mass matrix — makes `W`
+# matrix-free too; without this the default `all(isconvertible, getops(W)) ==
+# all(isconvertible, ()) == true` would wrongly claim a matrix-free `W` is convertible.
+isconvertible(W::WOperator) = isconvertible(W.mass_matrix) && isconvertible(W.J)
 Base.size(W::WOperator) = size(W.J)
 Base.size(W::WOperator, d::Integer) = d <= 2 ? size(W)[d] : 1
 function Base.getindex(W::WOperator, i::Int)

--- a/test/shared/WOperator.jl
+++ b/test/shared/WOperator.jl
@@ -52,3 +52,25 @@ Random.seed!(0)
     b = randn(n)
     @test W_mm \ b ≈ convert(AbstractMatrix, W_mm) \ b
 end
+
+@testset "WOperator isconvertible honesty" begin
+    n = 5
+    u = rand(n)
+    gamma = 0.1
+    Mmat = Matrix(1.0I, n, n)
+    concrete_J = MatrixOperator(rand(n, n))
+    # A matrix-free operator: only `mul!`, no `convert(AbstractMatrix, ·)`.
+    matfree(A) = FunctionOperator(
+        (w, v, p, t) -> mul!(w, A, v), zeros(n), zeros(n); islinear = true
+    )
+    matfree_J = matfree(rand(n, n))
+    matfree_M = matfree(Mmat)
+
+    @test isconvertible(matfree_J) == false
+    # `W` is convertible only when both the mass matrix and the Jacobian are; a matrix-free
+    # part on either side makes `W` matrix-free (previously `isconvertible(W)` was vacuously
+    # `true` because `getops(W) == ()`).
+    @test isconvertible(WOperator{true}(Mmat, gamma, concrete_J, u)) == true
+    @test isconvertible(WOperator{true}(Mmat, gamma, matfree_J, u)) == false
+    @test isconvertible(WOperator{true}(matfree_M, gamma, concrete_J, u)) == false
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

`WOperator` defined no `getops`/`isconvertible`, so it inherited the default
`isconvertible(L) = all(isconvertible, getops(L))` with `getops(W) == ()`, which is
vacuously `true`. A `WOperator` wrapping a **matrix-free** Jacobian (e.g. a
Jacobian–vector-product operator) — or a matrix-free mass matrix — therefore wrongly
reported itself as convertible to a concrete matrix, even though
`convert(AbstractMatrix, W)` (which fuses `-M/γ` with `convert(AbstractMatrix, W.J)`)
cannot materialize it.

This matters for consumers that gate factorize-vs-matrix-free on the trait (e.g.
NonlinearSolve, mirroring how `NLNewton` decides when a `W` can be factorized): a
matrix-free `W` claiming `isconvertible == true` would be routed to a factorization and
fail deep inside the linear solver instead of being applied via `mul!`.

Define:

```julia
isconvertible(W::WOperator) = isconvertible(W.mass_matrix) && isconvertible(W.J)
```

so the trait reflects what `convert` can actually do — `W` is convertible iff **both**
its mass matrix and its Jacobian are.

### Local verification
`test/shared/WOperator.jl` (Julia 1.12): **11/11 pass**, including the new
`"WOperator isconvertible honesty"` testset (concrete M + concrete J → `true`;
matrix-free J → `false`; matrix-free M → `false`).

Patch bump 1.24.0 → 1.24.1 (trait-correctness fix; no correct code relied on the
previous vacuous `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)