### PR TITLE
Fix copy(::MatrixOperator) dropping update_func!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.24.1"
+version = "1.24.2"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 
 [deps]

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -280,6 +280,7 @@ function Base.copy(L::MatrixOperator)
     return MatrixOperator(
         copy(L.A);
         update_func = L.update_func,
+        update_func! = L.update_func!,
         accepted_kwargs = NoKwargFilter()
     )
 end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -15,6 +15,16 @@ using Test
         # Check that copy is not affected
         @test L_copy.A[1, 1] != 999.0
         @test L_copy.A != L.A
+
+        # `copy` must preserve `update_func!` — both its type (so the result is not a
+        # different concrete type that can't be assigned back into a typed slot) and its
+        # behavior (a copy of a state-dependent operator stays state-dependent).
+        @test typeof(L_copy) === typeof(L)
+        M = MatrixOperator(zeros(2, 2); update_func! = (B, u, p, t) -> (B[1, 1] = u[1]; B))
+        M_copy = copy(M)
+        @test typeof(M_copy) === typeof(M)
+        update_coefficients!(M_copy, [7.0], nothing, nothing)
+        @test M_copy.A[1, 1] == 7.0
     end
 
     # Test DiagonalOperator (which is a MatrixOperator with Diagonal matrix)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

`Base.copy(L::MatrixOperator)` forwarded `update_func` but not `update_func!`, defaulting the copy's in-place updater to `nothing`. Two bugs:

- **Correctness**: a copy of a state-dependent operator silently lost its `update_func!`, so `update_coefficients!` on the copy became a no-op.
- **Type instability**: dropping the field changed the concrete type (the `update_func!` type parameter `FilterKwargs{…}` → `Nothing`), so the copy couldn't be assigned back into a slot typed for the original. In particular LinearSolve's `_copy_A_for_safety` — which copies `A` before an in-place `lu!` — throws a `MethodError` when `A` is a `MatrixOperator`:

```
MethodError: Cannot `convert` an object of type
  MatrixOperator{…, FilterKwargs{…}, Nothing} to an object of type
  MatrixOperator{…, FilterKwargs{…}, FilterKwargs{…}}
```

Fix: forward `update_func!` too, matching what `adjoint`/`conj` already do.

`test/copy.jl` gains checks that `copy` is type-preserving and that a copied `update_func!` still fires (`update_coefficients!` on the copy updates it). Full `copy.jl`: **29/29**.

Patch bump 1.24.1 → 1.24.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)