### PR TITLE
Repair downstream test targets

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -13,15 +13,16 @@ jobs:
       matrix:
         julia-version: [1]
         package:
-          - {user: SciML, repo: SciMLBase.jl, group: InterfaceII}
-          - {user: SciML, repo: DiffEqBase.jl, group: InterfaceII}
-          - {user: SciML, repo: LinearSolve.jl, group: InterfaceII}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII}
+          - {user: SciML, repo: SciMLBase.jl, subdir: "", group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: Core}
+          - {user: SciML, repo: LinearSolve.jl, subdir: "", group: Core}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: "", group: InterfaceIII}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"
       julia-arch: "x64"
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
     secrets: "inherit"


### PR DESCRIPTION
## Summary

- replace stale `InterfaceII` selections with groups that exercise SciMLOperators
- point the archived DiffEqBase repository entry at `OrdinaryDiffEq.jl/lib/DiffEqBase`
- pass the monorepo subdirectory through the shared downstream workflow

Depends on SciML/.github#115 for the reusable workflow `subdir` input.

Ignore this PR until reviewed by @ChrisRackauckas.

## Local verification

Each target was reproduced with this branch developed into the target environment:

- `SciMLBase/Core`: passed
- `OrdinaryDiffEq.jl/lib/DiffEqBase/Core`: passed
- `LinearSolve/Core`: passed
- `OrdinaryDiffEq/InterfaceIII`: passed (192 tests, 4 pre-existing broken tests across the displayed final groups)

Also passed:

- `/home/crackauc/.juliaup/bin/julialauncher +1.12 --startup-file=no -m Runic --check .`
- `git diff --check`