### PR TITLE
Rebuild WOperator._concrete_form on convert for operator-typed Jacobians

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.24.3"
+version = "1.24.4"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 
 [deps]

--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -190,10 +190,13 @@ function update_coefficients!(
 end
 
 function Base.convert(::Type{AbstractMatrix}, W::WOperator{IIP}) where {IIP}
-    if !IIP
+    if !IIP || W.J isa AbstractSciMLOperator
         # Mirror the constructor: materialize a MatrixOperator mass matrix so the
         # result type matches `_concrete_form` (otherwise this becomes an
         # AddedOperator and the assignment back into the Matrix-typed slot fails).
+        # The IIP case with a plain-matrix `J` is maintained externally via
+        # `jacobian2W!` writing into `_concrete_form`; when `J` is an operator no
+        # caller maintains it, so it must be rebuilt here with the current gamma.
         mm = W.mass_matrix isa MatrixOperator ?
             convert(AbstractMatrix, W.mass_matrix) : W.mass_matrix
         W._concrete_form = -mm / W.gamma + convert(AbstractMatrix, W.J)

--- a/test/shared/WOperator.jl
+++ b/test/shared/WOperator.jl
@@ -51,6 +51,22 @@ Random.seed!(0)
     # And `\` works end-to-end
     b = randn(n)
     @test W_mm \ b ≈ convert(AbstractMatrix, W_mm) \ b
+
+    # In-place WOperator with an operator-typed Jacobian: no external caller
+    # maintains _concrete_form (jacobian2W! only handles plain-matrix J), so
+    # convert must rebuild it with the current gamma. Regression test for the
+    # silently-stale form built at init with gamma = 0 (Inf diagonal), see
+    # SciML/OrdinaryDiffEq.jl#3933.
+    J_op = MatrixOperator(randn(n, n))
+    W_op = WOperator{true}(I(n), 0.0, J_op, randn(n))
+    update_coefficients!(W_op; gamma = 0.25)
+    @test convert(AbstractMatrix, W_op) ≈ -Matrix(1.0I, n, n) / 0.25 +
+        convert(AbstractMatrix, J_op)
+    @test all(isfinite, convert(AbstractMatrix, W_op))
+    # Rebuilt again after gamma changes
+    update_coefficients!(W_op; gamma = 0.5)
+    @test convert(AbstractMatrix, W_op) ≈ -Matrix(1.0I, n, n) / 0.5 +
+        convert(AbstractMatrix, J_op)
 end
 
 @testset "WOperator isconvertible honesty" begin


### PR DESCRIPTION
## Summary

Half of the fix for SciML/OrdinaryDiffEq.jl#3933 (implicit solvers on `SplitODEProblem(MatrixOperator(A), f)` + LU/KLU silently return garbage with `retcode: Success`).

For an in-place `WOperator` whose `J` is an `AbstractSciMLOperator`, no caller maintains `_concrete_form`: OrdinaryDiffEq's `calc_W!` skips `jacobian2W!` for operator Jacobians, so `convert(AbstractMatrix, W)` returned whatever was built at construction — with `gamma = 0` at integrator init, a matrix with `-Inf` diagonal. Concrete-A linear solvers factorized that Inf matrix, every Newton correction and ESDIRK error estimate collapsed to zero, and solves finished in ~2 giant accepted steps with unbounded error.

This rebuilds the concrete form with the current `gamma` whenever `J` is an operator, mirroring the OOP path. The plain-matrix IIP path is unchanged (still maintained externally via `jacobian2W!`).

The other half is SciML/OrdinaryDiffEq.jl PR fixing `do_newJW` to refactorize W when γdt drifts on the `islinearfunction` path; the end-to-end regression test lives there and needs this released as v1.24.4 first.

## Tests
- New unit test: IIP `WOperator` with `MatrixOperator` J built at `gamma = 0` converts to a finite, current-gamma matrix, and re-converts correctly after gamma updates.
- Full `Pkg.test()` run locally: all pass (Julia 1.12.6).
- End-to-end validation (with the OrdinaryDiffEq companion fix dev'd): KenCarp3/4/5 + `LUFactorization` on the 2×2 split repro give 3e-7–5e-5 errors matching the function-jac control, and the Kuramoto–Sivashinsky N=128 benchmark problem goes from relerr 4.4e15 to matching the GMRES reference, ~30× faster than the GMRES default.

Version bumped 1.24.3 → 1.24.4.

---

**Note: please ignore this PR until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDVGmmovzD5Aos3fFoPwMY