### PR TITLE
Fix WOperator conversion for composite Jacobians

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.24.4"
+version = "1.24.5"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 
 [deps]

--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -199,7 +199,11 @@ function Base.convert(::Type{AbstractMatrix}, W::WOperator{IIP}) where {IIP}
         # caller maintains it, so it must be rebuilt here with the current gamma.
         mm = W.mass_matrix isa MatrixOperator ?
             convert(AbstractMatrix, W.mass_matrix) : W.mass_matrix
-        W._concrete_form = -mm / W.gamma + convert(AbstractMatrix, W.J)
+        concrete_form = -mm / W.gamma + convert(AbstractMatrix, W.J)
+        # Operator arithmetic can make `_concrete_form` lazy even though its
+        # concretization is a matrix, so the rebuilt value may not fit its field type.
+        W.J isa AbstractSciMLOperator && return concrete_form
+        W._concrete_form = concrete_form
     end
     return W._concrete_form
 end

--- a/test/shared/WOperator.jl
+++ b/test/shared/WOperator.jl
@@ -67,6 +67,15 @@ Random.seed!(0)
     update_coefficients!(W_op; gamma = 0.5)
     @test convert(AbstractMatrix, W_op) ≈ -Matrix(1.0I, n, n) / 0.5 +
         convert(AbstractMatrix, J_op)
+
+    J_sum = MatrixOperator(randn(n, n)) + MatrixOperator(randn(n, n))
+    W_sum = WOperator{true}(I, 0.0, J_sum, randn(n))
+    update_coefficients!(W_sum; gamma = 0.25)
+    @test convert(AbstractMatrix, W_sum) ≈ -Matrix(1.0I, n, n) / 0.25 +
+        convert(AbstractMatrix, J_sum)
+    update_coefficients!(W_sum; gamma = 0.5)
+    @test convert(AbstractMatrix, W_sum) ≈ -Matrix(1.0I, n, n) / 0.5 +
+        convert(AbstractMatrix, J_sum)
 end
 
 @testset "WOperator isconvertible honesty" begin


### PR DESCRIPTION
## Summary

- Return the rebuilt concrete matrix directly when `WOperator.J` is an `AbstractSciMLOperator` instead of assigning it into a potentially lazy operator-typed `_concrete_form` field.
- Preserve the current-gamma rebuilding behavior added by #408.
- Add a regression test for an in-place `WOperator` whose Jacobian is a composite `AddedOperator`.
- Bump SciMLOperators to v1.24.5.

## Regression and cause

On clean OrdinaryDiffEq master `8fc48e69`, with LinearSolve v4.3.0 and SciMLOperators v1.24.4, the OrdinaryDiffEqAMF Core suite reports `13 passed, 2 errored`. Both errors come from `convert(AbstractMatrix, W)` attempting to assign a `Matrix{Float64}` into an `_concrete_form` field concretely typed as an `AddedOperator`.

The version boundary and source history identify #408 / merge commit `d1f46ec` as the introducing change: it extended the rebuild-and-assign path to in-place operator Jacobians in v1.24.4. The rebuild itself is required; only storing the rebuilt matrix is invalid when construction produced a lazy composite cache.

## Local validation

- `GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: passed (`958` assertions passed across the reported Core testsets; the package's two pre-existing broken assertions remain).
- Whole-repository Runic `--check`: passed with exit code 0.
- OrdinaryDiffEqAMF clean-master cross-checks at v1.24.3 and with this branch are running and will be posted as a PR comment when complete.

---

**Please ignore this PR until reviewed by @ChrisRackauckas.**

Generated during an automated regression investigation triggered by downstream CI.
