### PR TITLE
Cover tensor-product Jacobians in the WOperator convert test

### DIFF
--- a/test/shared/WOperator.jl
+++ b/test/shared/WOperator.jl
@@ -76,6 +76,23 @@ Random.seed!(0)
     update_coefficients!(W_sum; gamma = 0.5)
     @test convert(AbstractMatrix, W_sum) ≈ -Matrix(1.0I, n, n) / 0.5 +
         convert(AbstractMatrix, J_sum)
+
+    # Tensor-product Jacobian graph (the OrdinaryDiffEq AMF fd2d shape). Unlike
+    # the AddedOperator of MatrixOperators above, these report
+    # `isconvertible == false` yet still convert to an AbstractMatrix.
+    N = 4
+    h = 1 / (N + 1)
+    D_op = MatrixOperator((1 / h^2) * Tridiagonal(ones(N - 1), -2 * ones(N), ones(N - 1)))
+    J_kron = cache_operator(
+        0.1 * Base.kron(D_op, IdentityOperator(N)) +
+            0.1 * Base.kron(IdentityOperator(N), D_op),
+        zeros(N^2)
+    )
+    @test !isconvertible(J_kron)
+    W_kron = WOperator{true}(I, 1.0, J_kron, randn(N^2))
+    update_coefficients!(W_kron; gamma = 0.25)
+    @test convert(AbstractMatrix, W_kron) ≈ -Matrix(1.0I, N^2, N^2) / 0.25 +
+        convert(AbstractMatrix, J_kron)
 end
 
 @testset "WOperator isconvertible honesty" begin


### PR DESCRIPTION
**This PR should be ignored until reviewed by @ChrisRackauckas.**

Rebased onto master. **Scope changed** — please re-read.

## What happened

https://github.com/SciML/SciMLOperators.jl/pull/410 merged as `bd6d1df` while
this was open, and it fixes the same bug from the `convert` side:

```julia
W.J isa AbstractSciMLOperator && return concrete_form
```

I re-tested the original reproduction against master and it now passes, so the
source change this PR carried is **redundant** and has been dropped:

```julia
julia> J = MatrixOperator(rand(4,4)) + MatrixOperator(rand(4,4))
julia> W = SciMLOperators.WOperator{true}(I, 1.0, J, rand(4))
julia> convert(AbstractMatrix, W)
# master: Matrix{Float64}   (was: MethodError)
```

The tensor-product shape that actually broke OrdinaryDiffEq's AMF fd2d run also
passes on master:

```
tensor-product sum     OK  Matrix{Float64} (9, 9)
single kron            OK  Matrix{Float64} (9, 9)
```

I also checked whether the constructor-side change this PR had was still worth
keeping for caching. It is not: with an operator `J` the concrete form has to be
rebuilt per `gamma` on every `convert` regardless, so both spellings recompute
and the assignment only decides where the result is stored. No performance
difference.

## What is left

The regression test. #410's test covers an `AddedOperator` of two
`MatrixOperator`s; the AMF case is narrower — `kron`-built graphs report
`isconvertible == false` yet still convert to an `AbstractMatrix`, reaching the
same failed assignment by a different path. This PR now adds only that shape:

```julia
J_kron = cache_operator(
    0.1 * Base.kron(D_op, IdentityOperator(N)) +
        0.1 * Base.kron(IdentityOperator(N), D_op),
    zeros(N^2))
@test !isconvertible(J_kron)
W_kron = WOperator{true}(I, 1.0, J_kron, randn(N^2))
update_coefficients!(W_kron; gamma = 0.25)
@test convert(AbstractMatrix, W_kron) ≈ -Matrix(1.0I, N^2, N^2) / 0.25 +
    convert(AbstractMatrix, J_kron)
```

Diff is now `test/shared/WOperator.jl`, +17 lines, no source change.

## Verification

Runs the real test file, not a paraphrase:

| Commit | `test/shared/WOperator.jl` |
|---|---|
| `4ad418c` (pre-#410) | `3 errored` — `MethodError: Cannot convert Matrix{Float64} to AddedOperator{...}` |
| `bd6d1df` (master) | `WOperator \| 14 passed` |

So it fails on the buggy code and passes on the fix — worth keeping rather than
closing this PR outright.

If you would rather not carry the extra case, closing this is fine; #410 already
covers the correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPHRh64BLfoXSzQ3AxKNwC
