### PR TITLE
Fix update_coefficients! for out-of-place-only update funcs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.25.1"
+version = "1.25.2"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 
 [deps]

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -112,7 +112,14 @@ function update_coefficients!(L::BatchedDiagonalOperator, u, p, t; kwargs...)
     if !isnothingfunc(L.update_func!)
         L.update_func!(L.diag, u, p, t; kwargs...)
     elseif !isnothingfunc(L.update_func)
-        L.diag = L.update_func(L.diag, u, p, t; kwargs...)
+        if !ArrayInterface.ismutable(L.diag)
+            msg = """`update_coefficients!` cannot update a `BatchedDiagonalOperator`
+            holding an immutable diagonal ($(typeof(L.diag))) through an
+            out-of-place `update_func`. Use `update_coefficients(L, u, p, t)`
+            instead, or construct the operator with a mutating `update_func!`."""
+            throw(ArgumentError(msg))
+        end
+        copyto!(L.diag, L.update_func(L.diag, u, p, t; kwargs...))
     end
     return nothing
 end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -244,7 +244,14 @@ function update_coefficients!(L::MatrixOperator, u, p, t; kwargs...)
     if !isnothingfunc(L.update_func!)
         L.update_func!(L.A, u, p, t; kwargs...)
     elseif !isnothingfunc(L.update_func)
-        L.A = L.update_func(L.A, u, p, t; kwargs...)
+        if !ArrayInterface.ismutable(L.A)
+            msg = """`update_coefficients!` cannot update a `MatrixOperator` holding
+            an immutable matrix ($(typeof(L.A))) through an out-of-place
+            `update_func`. Use `update_coefficients(L, u, p, t)` instead, or
+            construct the operator with a mutating `update_func!`."""
+            throw(ArgumentError(msg))
+        end
+        copyto!(L.A, L.update_func(L.A, u, p, t; kwargs...))
     end
     return nothing
 end

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -165,6 +165,17 @@ end
     L(w, v, u, p, t, α, β)
     @test w ≈ α * (A * v) + β * orig_w
 
+    # update_coefficients! with only an out-of-place update_func (#409)
+    Loop = MatrixOperator(zeros(N, N); update_func = (A, u, p, t) -> p * p')
+    update_coefficients!(Loop, u, p, t)
+    @test convert(AbstractMatrix, Loop) ≈ p * p'
+
+    # immutable storage cannot be updated in place through an out-of-place func
+    Limm = MatrixOperator(
+        reshape(1.0:(N * N), N, N); update_func = (A, u, p, t) -> p * p'
+    )
+    @test_throws ArgumentError update_coefficients!(Limm, u, p, t)
+
     A = [
         -2.0 1 0 0 0
         1 -2 1 0 0
@@ -329,6 +340,19 @@ end
     copy!(w, zeros(N, K))
     D(w, v, u, p, t)
     @test w ≈ expected
+
+    # update_coefficients! with only an out-of-place update_func (#409)
+    Doop = DiagonalOperator(zeros(N, K); update_func = (diag, u, p, t) -> p * t)
+    update_coefficients!(Doop, u, p, t)
+    copy!(w, zeros(N, K))
+    mul!(w, Doop, v)
+    @test w ≈ (p * t) .* v
+
+    # immutable storage cannot be updated in place through an out-of-place func
+    Dimm = DiagonalOperator(
+        reshape(1.0:(N * K), N, K); update_func = (diag, u, p, t) -> p * t
+    )
+    @test_throws ArgumentError update_coefficients!(Dimm, u, p, t)
 end
 
 @testset "AffineOperator" begin


### PR DESCRIPTION
Fixes #409.

`MatrixOperator` is an immutable struct, but `update_coefficients!` assigns `L.A = L.update_func(...)` when the operator was built with only an out-of-place `update_func` (src/matrix.jl:247 at v1.25.1), so every call throws:

```
ERROR: setfield!: immutable struct of type MatrixOperator cannot be changed
```

The out-of-place `update_coefficients` already handles this configuration correctly via `@reset`. The same bug exists a second time for `BatchedDiagonalOperator` (src/batch.jl:115): `DiagonalOperator(u::AbstractMatrix; update_func = ...)` crashes identically. #409 only mentions `MatrixOperator`; this PR fixes both sites.

## Fix

When only `update_func` is provided, compute the new value out-of-place and `copyto!` it into the existing storage when that storage is mutable. When the storage is immutable (`!ArrayInterface.ismutable`), throw a descriptive `ArgumentError` pointing to `update_coefficients` — matching how in-place application is handled elsewhere for immutable storage.

## Tests

Added to the existing `MatrixOperator update test` and `Batched DiagonalOperator update test` testsets:

- `update_coefficients!` with only `update_func` now updates the operator (both types) — this was the crash path, previously uncovered (the existing update testsets always set `update_func` and `update_func!` together).
- Immutable storage (`reshape(range, ...)`) with only `update_func` throws `ArgumentError`.

`test/matrix.jl`: 291 pass, 1 pre-existing broken. Runic clean. Version bumped 1.25.1 → 1.25.2.

## AI Disclosure

Claude assisted with this work.
