### PR TITLE
docs: document SciMLOperators interface contracts

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -40,6 +40,16 @@ SciMLOperators.NoKwargFilter
 
 ## Developer Extension Hooks
 
+The names in this section are qualified, developer-facing extension points.
+They are documented so solver packages can depend on a stable contract, but
+they are not general user construction APIs. Downstream solver developers
+should extend the documented methods rather than relying on private fields or
+unexported implementation helpers.
+
+```@docs
+SciMLOperators.AbstractWOperator
+```
+
 ```@docs
 SciMLOperators.has_tensor_outer_mul_fast
 SciMLOperators.tensor_outer_mul_fast!

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -12,6 +12,9 @@ update_coefficients
 update_coefficients!
 cache_operator
 concretize
+jacobian_stale
+mark_jacobian_updated!
+mark_jacobian_current!
 SciMLOperators.DEFAULT_UPDATE_FUNC
 ```
 

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -33,9 +33,15 @@ const isv1 = true
 """
 $(TYPEDEF)
 
-Subtypes of `AbstractSciMLOperator` represent linear, nonlinear,
-time-dependent operators acting on vectors, or matrix column-vectors.
-A lazy operator algebra is also defined for `AbstractSciMLOperator`s.
+`AbstractSciMLOperator` is the extension point for matrix-like and
+matrix-free operators. A subtype represents an operator ``L(u,p,t)`` whose
+action on an array ``v`` is written ``L(u,p,t)v``. The subtype may be
+constant, state-dependent, or time-dependent, and may be composed with other
+SciML operators through the lazy algebra.
+
+This is an interface type, not a constructor. The concrete type should be
+public only when users are expected to construct or extend it; otherwise use
+the qualified developer-facing API documented in this section.
 
 ## Mathematical Notation
 
@@ -55,6 +61,18 @@ operator types should subtype it with the scalar element type `T` and must
 preserve their mathematical action when they participate in lazy algebra.
 
 ## Required Interface
+
+A concrete subtype must implement `size(L) -> (m, n)`, `*(L, v)`, and
+`mul!(w, L, v)`. The returned action has leading size `m` for an input whose
+leading size is `n`, and the in-place method must return `w` after writing the
+result. The scaling form `mul!(w, L, v, α, β)` is required when
+`has_mul!(L) == true`; it must compute ``w \\leftarrow α(Lv) + βw``.
+
+`has_mul(L)`, `has_mul!(L)`, `has_ldiv(L)`, and `has_ldiv!(L)` are promises,
+not capability probes: return `true` only when the corresponding operation is
+valid for all compatible inputs. `convert(AbstractMatrix, L)` is optional and
+should be defined only when `isconvertible(L) == true`; its result must have
+the same size and action as `L` in its current state.
 
 An `AbstractSciMLOperator` can be called like a function in the following ways:
 
@@ -86,9 +104,17 @@ application paths:
 
 If the operator state depends on `(u, p, t)` or accepted keyword arguments,
 the subtype must implement `update_coefficients` for out-of-place state
-updates or `update_coefficients!` for in-place state updates. Composite
-operators assume these update methods may be called recursively on every
-operator returned by `getops(L)`.
+updates or `update_coefficients!` for in-place state updates. The out-of-place
+form returns a new operator and leaves `L` unchanged; the in-place form
+returns `nothing`. Composite operators assume these update methods may be
+called recursively on every operator returned by `getops(L)`.
+
+The positional arguments are forwarded unchanged through a composite
+operator. `u` is the state supplied by the caller and is not necessarily the
+same shape as the action vector `v`; an operator whose action is nonlinear in
+`v` should generally use `FunctionOperator` and report `islinear(L) == false`.
+For a constant leaf, the default update is a no-op. A stateful leaf must
+override `isconstant` rather than inheriting the empty-child default.
 
 Subtypes that need preallocated work arrays for allocation-free application
 must implement `cache_self(L, v)` for their own caches, `cache_internals(L, v)`
@@ -101,6 +127,13 @@ and downstream solvers may call it before repeated `mul!` evaluations.
 subtype that advertises `has_mul!(L) == true` must ensure the cached result is
 ready for repeated `mul!` calls with compatible vectors. Cache hooks may not
 change the mathematical action, dimensions, or trait values of the operator.
+A cached operator's scratch is mutable and is not safe to use concurrently
+unless the subtype explicitly provides that guarantee.
+
+Composite types expose their children through the developer-facing `getops`
+method. A new composite must forward state updates, caching, and traits to
+every child that contributes to its action. The public action must remain
+unchanged by flattening, caching, or updating the composition.
 
 ## Trait Rules
 
@@ -121,10 +154,12 @@ for a linear operator.
 ## Keyword Arguments
 
 When an operator accepts keywords during updates, its constructor must record
-the accepted names with `accepted_kwargs`. Composite operators forward only
-those accepted keywords to each component. Extension authors must therefore
-accept `(u, p, t; kwargs...)` consistently in every update and application
-method they advertise.
+the accepted names with `accepted_kwargs`, normally as
+`Val((:name1, :name2))`. Composite operators forward only those accepted
+keywords to each component. Extension authors must therefore accept
+`(u, p, t; kwargs...)` consistently in every update and application method
+they advertise. An unlisted keyword must not be silently passed to a leaf
+update function.
 
 ## Standard Actions
 
@@ -144,10 +179,14 @@ SciMLOperator can also be applied to `AbstractMatrix` subtypes where
 operator-evaluation is done column-wise.
 
 ```julia
+using LinearAlgebra, SciMLOperators
+
+N = 4
 K = 10
+L = MatrixOperator(Matrix(I, N, N))
 u_mat = rand(N, K)
 
-v_mat = F(u_mat, p, t) # == mul!(v_mat, F, u_mat)
+v_mat = L(u_mat, nothing, nothing, 0.0)
 size(v_mat) == (N, K) # true
 ```
 
@@ -168,30 +207,34 @@ or out-of-place, i.e. in a non-mutating, `Zygote`-compatible way.
 For example,
 
 ```julia
-u = rand(N)
-p = rand(N)
+using LinearAlgebra, SciMLOperators
+
+n = 4
+v = rand(n)
+u = rand(n)
+p = rand(n)
 t = rand()
 
 # out-of-place update
 mat_update_func = (A, u, p, t) -> t * (p * u')
 sca_update_func = (a, u, p, t) -> t * sum(p)
 
-M = MatrixOperator(zero(N, N); update_func = mat_update_func)
-α = ScalarOperator(zero(Float64); update_func = sca_update_func)
+M = MatrixOperator(zeros(n, n); update_func = mat_update_func)
+α = ScalarOperator(0.0; update_func = sca_update_func)
 
 L = α * M
 L = cache_operator(L, v)
 
 # L is initialized with zero state
-L * v == zeros(N) # true
+L * v == zeros(n) # true
 
 # update operator state with `(u, p, t)`
 L = update_coefficients(L, u, p, t)
 # and multiply
-L * v != zeros(N) # true
+L * v != zeros(n) # true
 
 # updates state and evaluates L*v at (u, p, t)
-L(v, u, p, t) != zeros(N) # true
+L(v, u, p, t) != zeros(n) # true
 ```
 
 The out-of-place evaluation function `L(v, u, p, t)` calls
@@ -207,34 +250,34 @@ followed by `mul!`. The in-place update behavior works the same way,
 with a few `<!>`s appended here and there. For example,
 
 ```julia
-w = rand(N)
-v = rand(N)
-u = rand(N)
-p = rand(N)
+using LinearAlgebra, SciMLOperators
+
+n = 4
+w = rand(n)
+v = rand(n)
+u = rand(n)
+p = rand(n)
 t = rand()
 
 # in-place update
-_A = rand(N, N)
-_d = rand(N)
+_A = rand(n, n)
 mat_update_func! = (A, u, p, t) -> (copy!(A, _A); lmul!(t, A); nothing)
-diag_update_func! = (diag, u, p, t) -> copy!(diag, N)
 
-M = MatrixOperator(zero(N, N); update_func! = mat_update_func!)
-D = DiagonalOperator(zero(N); update_func! = diag_update_func!)
+M = MatrixOperator(zeros(n, n); update_func! = mat_update_func!)
 
-L = D * M
+L = M
 L = cache_operator(L, v)
 
 # L is initialized with zero state
-L * v == zeros(N) # true
+L * v == zeros(n) # true
 
 # update L in-place
 update_coefficients!(L, v, p, t)
 # and multiply
-mul!(w, v, u, p, t) != zero(N) # true
+mul!(w, L, v) != zeros(n) # true
 
 # updates L in-place, and evaluates w=L*v at (u, p, t)
-L(w, v, u, p, t) != zero(N) # true
+L(w, v, u, p, t) != zeros(n) # true
 ```
 
 The update behavior makes this package flexible enough to be used
@@ -244,13 +287,20 @@ prefer to pass in state information via other arguments. For that
 reason, we allow update functions with arbitrary keyword arguments.
 
 ```julia
+using SciMLOperators
+
+n = 4
+v = rand(n)
+u = rand(n)
+p = rand(n)
+t = 0.0
 mat_update_func = (A, u, p, t; scale = 0.0) -> scale * (p * u')
 
-M = MatrixOperator(zero(N, N); update_func = mat_update_func,
-    accepted_kwargs = (:state,))
+M = MatrixOperator(zeros(n, n); update_func = mat_update_func,
+    accepted_kwargs = Val((:scale,)))
 
-M(v, u, p, t) == zeros(N) # true
-M(v, u, p, t; scale = 1.0) != zero(N)
+M(v, u, p, t) == zeros(n) # true
+M(v, u, p, t; scale = 1.0) != zeros(n)
 ```
 """
 abstract type AbstractSciMLOperator{T} end
@@ -263,11 +313,35 @@ Abstract interface for a scalar-valued linear scaling operator.
 # Interface Rules
 
 Subtypes must provide `convert(Number, operator)` for their current scalar
-value. They may implement state updates through `update_coefficients` and
-`update_coefficients!` using the same `(u, p, t; kwargs...)` contract as
-[`AbstractSciMLOperator`](@ref). Scalar operators act on numbers and arrays,
-and their addition, multiplication, division, and inversion remain lazy so
-that later updates affect the composed expression.
+value and `eltype` through the type parameter `T`. Scalar application to an
+array must preserve the array shape. If the subtype is stateful, its update
+methods use the same `(u, p, t; kwargs...)` contract as
+[`AbstractSciMLOperator`](@ref): the out-of-place form returns a new scalar
+operator, while the in-place form mutates the operator and returns `nothing`.
+
+`islinear` describes linearity in the array being scaled. `has_ldiv` and
+`has_ldiv!` may be true only when the current scalar value is invertible.
+Scalar addition, multiplication, division, and inversion remain lazy so that
+later updates affect the composed expression. Use `ScalarOperator` when a
+premade implementation is sufficient.
+
+# Examples
+
+```julia
+using SciMLOperators
+
+struct MutableScale <: AbstractSciMLScalarOperator{Float64}
+    value::Float64
+end
+
+Base.convert(::Type{Number}, L::MutableScale) = L.value
+Base.:*(L::MutableScale, v::AbstractArray) = L.value .* v
+SciMLOperators.islinear(::MutableScale) = true
+
+L = MutableScale(2.0)
+L * [3.0, 4.0]
+concretize(L) == 2.0
+```
 
 Use `ScalarOperator` to construct a concrete scalar operator. Custom scalar
 operator types should only claim traits such as `has_ldiv` when the converted

--- a/src/SciMLOperators.jl
+++ b/src/SciMLOperators.jl
@@ -402,6 +402,7 @@ export update_coefficients!,
 # Documented but not exported: core abstract types, lazy-algebra result types,
 # and developer extension hooks used through qualified access downstream.
 @public AbstractSciMLOperator, AbstractSciMLScalarOperator,
+    AbstractWOperator,
     ScaledOperator, AddedOperator, ComposedOperator,
     InvertedOperator, AdjointOperator, TransposedOperator,
     AddedScalarOperator, ComposedScalarOperator, InvertedScalarOperator,

--- a/src/func.jl
+++ b/src/func.jl
@@ -311,6 +311,17 @@ Trait keyword arguments must be truthful and uniform across `op`, `op_adjoint`,
   - `ishermitian` - `true` if the operator is linear and hermitian. Defaults to `false`.
   - `isposdef` - `true` if the operator is linear and positive-definite. Defaults to `false`.
   - `kwargs` - Keyword arguments for cache initialization. If `accepted_kwargs` is provided, the corresponding keyword arguments must be passed.
+
+# Returns
+
+A matrix-free `FunctionOperator` whose size, element type, cache layout, and
+traits are inferred from `input`, `output`, and the trait keyword arguments.
+
+# Errors
+
+Construction throws when the input and output prototypes have incompatible
+dimensions, when a requested batch layout is invalid, or when the callable
+does not satisfy the selected in-place/out-of-place contract.
 """
 function FunctionOperator(
         op,

--- a/src/func.jl
+++ b/src/func.jl
@@ -319,9 +319,9 @@ traits are inferred from `input`, `output`, and the trait keyword arguments.
 
 # Errors
 
-Construction throws when the input and output prototypes have incompatible
-dimensions, when a requested batch layout is invalid, or when the callable
-does not satisfy the selected in-place/out-of-place contract.
+Construction validates the input/output prototype dimensions and requested
+batch layout. Application or cache initialization can throw when the
+callable does not satisfy the selected in-place/out-of-place contract.
 """
 function FunctionOperator(
         op,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,6 +9,18 @@ $SIGNATURES
 
 The default update function for `AbstractSciMLOperator`s, a no-op that
 leaves the operator state unchanged.
+
+# Arguments
+
+  - `A`: Current operator state.
+  - `u`: State or update vector supplied by the caller.
+  - `p`: Parameter object supplied by the caller.
+  - `t`: Time or other scalar update value.
+
+# Returns
+
+The unchanged value `A`. The positional update arguments are accepted so this
+function can be used wherever an operator update function is expected.
 """
 DEFAULT_UPDATE_FUNC(A, u, p, t) = A
 
@@ -40,7 +52,23 @@ This method is out-of-place, i.e. fully non-mutating and `Zygote`-compatible.
 
 $(UPDATE_COEFFS_WARNING)
 
-# Example
+# Arguments
+
+  - `L`: Operator whose state should be updated.
+  - `u`: State or update vector supplied to the operator.
+  - `p`: Parameter object supplied to the operator.
+  - `t`: Time or other scalar update value.
+
+# Keyword Arguments
+
+  - `kwargs...`: Keywords accepted by the operator's update function and
+    recorded by its `accepted_kwargs` constructor option.
+
+# Returns
+
+A new operator representing the updated state. `L` is not mutated.
+
+# Examples
 
 ```
 using SciMLOperators
@@ -79,7 +107,23 @@ corresponding to the symbols provided to the operator via kwarg
 
 $(UPDATE_COEFFS_WARNING)
 
-# Example
+# Arguments
+
+  - `L`: Operator whose state should be updated.
+  - `u`: State or update vector supplied to the operator.
+  - `p`: Parameter object supplied to the operator.
+  - `t`: Time or other scalar update value.
+
+# Keyword Arguments
+
+  - `kwargs...`: Keywords accepted by the operator's mutating update function
+    and recorded by its `accepted_kwargs` constructor option.
+
+# Returns
+
+`nothing`. The operator `L` is mutated in place.
+
+# Examples
 
 ```
 using SciMLOperators
@@ -142,6 +186,15 @@ getops(L) = ()
 $SIGNATURES
 
 Checks whether `L` has preallocated caches for inplace evaluations.
+
+# Arguments
+
+  - `L`: Operator to inspect. For a composite, all child caches are checked.
+
+# Returns
+
+`true` when the operator and every child needed for in-place evaluation has a
+usable cache, otherwise `false`.
 """
 function iscached(L::AbstractSciMLOperator)
     has_cache = hasfield(typeof(L), :cache) # TODO - confirm this is static
@@ -169,6 +222,23 @@ iscached(
 $SIGNATURES
 
 Allocate caches for `L` for in-place evaluation with `u`-like input vectors.
+
+# Arguments
+
+  - `L`: Operator to prepare.
+  - `u`: Prototype vector or matrix whose shape determines compatible scratch.
+
+# Returns
+
+`L` or a cached replacement. The returned operator must have the same action,
+size, and trait values as the input operator.
+
+# Interface Rules
+
+Call this before repeated `mul!` or callable in-place evaluations when the
+operator needs scratch storage. A custom type that needs storage should
+implement `cache_self` for its own buffers and `cache_internals` for child
+operators.
 """
 cache_operator(L, u) = L
 
@@ -217,6 +287,17 @@ $SIGNATURES
 
 Replace `op`'s cache with `new_cache`. Only ever called with a `new_cache` of exactly
 the same type as the one it replaces, so `op`'s type is unchanged.
+
+# Arguments
+
+  - `op`: Cached operator whose scratch should be replaced.
+  - `new_cache`: Cache with the same type, shape, and aliasing layout as the
+    existing cache.
+
+# Returns
+
+An operator with `new_cache` installed. Implementations must preserve the
+operator action and type parameters.
 """
 update_cache(op::AbstractSciMLOperator, new_cache) = @reset op.cache = new_cache
 
@@ -293,6 +374,17 @@ that is checked against buffers that already exist. This additionally claims tha
 that is what the caller compares before any buffer exists. Leave it undefined when the cache
 depends on anything else — `FunctionOperator` does, because it sizes buffers from
 `traits.sizes`, which `size` does not expose.
+
+# Arguments
+
+  - `op`: Operator that may adopt the supplied cache.
+  - `cache`: An interchangeable cache from another operator.
+  - `v`: Prototype action vector or matrix used to build child caches.
+
+# Returns
+
+An operator using `cache`, or `nothing` to decline. Returning an operator that
+silently allocates a different cache is a contract violation.
 """
 adopt_cache(::AbstractSciMLOperator, cache, v) = nothing
 
@@ -360,6 +452,15 @@ Base.iszero(::AbstractSciMLOperator) = false # TODO
 $SIGNATURES
 
 Check if `adjoint(L)` is lazily defined.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when `adjoint(L)` is supported without relying on an
+unadvertised conversion fallback.
 """
 has_adjoint(L::AbstractSciMLOperator) = false # L', adjoint(L)
 """
@@ -367,6 +468,15 @@ $SIGNATURES
 
 Check if `expmv!(w, L, v, t)`, equivalent to `mul!(w, exp(t * A), v)`, is
 defined for `Number` `t`, and `AbstractArray`s `w, v` of appropriate sizes.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when the in-place exponential action is part of the operator's
+supported contract.
 """
 has_expmv!(L::AbstractSciMLOperator) = false # expmv!(v, L, t, u)
 """
@@ -374,18 +484,42 @@ $SIGNATURES
 
 Check if `expmv(L, v, t)`, equivalent to `exp(t * A) * v`, is defined for
 `Number` `t`, and `AbstractArray` `u` of appropriate size.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when the out-of-place exponential action is supported.
 """
 has_expmv(L::AbstractSciMLOperator) = false # v = exp(L, t, u)
 """
 $SIGNATURES
 
-Check if `exp(L)` is defined lazily defined.
+Check if `exp(L)` is defined lazily.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when `exp(L)` is a supported lazy operation.
 """
 has_exp(L::AbstractSciMLOperator) = islinear(L)
 """
 $SIGNATURES
 
 Check if `L * v` is defined for `AbstractArray` `u` of appropriate size.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when `L * v` is supported for compatible action arrays.
 """
 has_mul(L::AbstractSciMLOperator) = true # du = L*u
 """
@@ -393,12 +527,30 @@ $SIGNATURES
 
 Check if `mul!(w, L, v)` is defined for `AbstractArray`s `w, v` of
 appropriate sizes.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when the in-place multiplication and its return-value contract
+are supported for compatible arrays.
 """
 has_mul!(L::AbstractSciMLOperator) = true # mul!(du, L, u)
 """
 $SIGNATURES
 
 Check if `L \\ v` is defined for `AbstractArray` `v` of appropriate size.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when the out-of-place solve is supported for compatible right-hand
+sides.
 """
 has_ldiv(L::AbstractSciMLOperator) = false # du = L\u
 """
@@ -406,6 +558,14 @@ $SIGNATURES
 
 Check if `ldiv!(w, L, v)` is defined for `AbstractArray`s `w, v` of
 appropriate sizes.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when the in-place solve is supported for compatible arrays.
 """
 has_ldiv!(L::AbstractSciMLOperator) = false # ldiv!(du, L, u)
 
@@ -416,6 +576,15 @@ $SIGNATURES
 
 Checks if an `L`'s state is constant or needs to be updated by calling
 `update_coefficients`.
+
+# Arguments
+
+  - `L`: Operator or operator-like object to inspect.
+
+# Returns
+
+`true` when updating with supported `(u, p, t; kwargs...)` values cannot change
+the operator action. A stateful leaf must override this trait explicitly.
 """
 isconstant(
     ::Union{# LinearAlgebra
@@ -432,6 +601,16 @@ isconstant(L) = false
     isconvertible(L) -> Bool
 
 Checks if `L` can be cheaply converted to an `AbstractMatrix` via eager fusion.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` only when `convert(AbstractMatrix, L)` is a supported operation for the
+current operator state. This trait does not require eager conversion to be the
+preferred execution path.
 """
 isconvertible(L::AbstractSciMLOperator) = all(isconvertible, getops(L))
 
@@ -459,6 +638,21 @@ end
 
 Convert `SciMLOperator` to a concrete type via eager fusion. This method is a
 no-op for types that are already concrete.
+
+# Arguments
+
+  - `L`: Matrix-like or scalar operator to materialize.
+
+# Returns
+
+An `AbstractMatrix` for matrix-like operators or a `Number` for scalar
+operators, with the same current action as `L`.
+
+# Errors
+
+Throws the conversion error from `L` when the operator does not support the
+requested concrete representation. Check `isconvertible(L)` before relying
+on eager matrix materialization.
 """
 function concretize(
         L::Union{# LinearAlgebra
@@ -489,6 +683,15 @@ end
 $SIGNATURES
 
 Checks if `L` is a linear operator.
+
+# Arguments
+
+  - `L`: Operator to inspect.
+
+# Returns
+
+`true` when the action is linear in the action vector, even if the operator
+state depends on `(u, p, t)`.
 """
 islinear(::AbstractSciMLOperator) = false
 islinear(L) = false
@@ -552,6 +755,16 @@ has_adjoint(
 
 """
 Checks if `size(L, 1) == size(L, 2)`.
+
+# Arguments
+
+  - `L`: Matrix-like object or operator to inspect.
+
+# Returns
+
+`true` for a square operator and `false` for a rectangular operator or vector.
+For multiple arguments, the result is the elementwise conjunction of their
+individual square predicates.
 """
 issquare(L) = ndims(L) >= 2 && size(L, 1) == size(L, 2)
 issquare(::AbstractVector) = false

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -49,18 +49,32 @@ adjoints, and transposes. An update function must preserve the dimensions and
 mathematical meaning of `A`; use `FunctionOperator` when the action itself is
 nonlinear in the input vector.
 
+# Returns
+
+A `MatrixOperator` whose current action is `A`. When update functions are
+provided, the returned operator stores them and applies them through the
+documented update interface.
+
+# Errors
+
+Construction throws if `A` is not an `AbstractMatrix` or if a supplied update
+function returns a value incompatible with the matrix action. Passing a
+keyword not listed in `accepted_kwargs` is rejected by the keyword filter.
+
 # Examples
 
 Out-of-place update and usage
 
 ```
+using LinearAlgebra, SciMLOperators
+
 v = rand(4)
 u = rand(4)
 p = rand(4, 4)
 t = rand()
 
 mat_update = (A, u, p, t; scale = 0.0) -> t * p
-M = MatrixOperator(0.0; update_func = mat_update, accepted_kwargs = Val((:scale,)))
+M = MatrixOperator(zeros(4, 4); update_func = mat_update, accepted_kwargs = Val((:scale,)))
 
 L = M * M + 3I
 L = cache_operator(L, v)
@@ -403,7 +417,23 @@ Updates must preserve the diagonal's leading dimension. For multidimensional
 `diag`, the operator acts elementwise while reporting a matrix size based on
 its leading dimension.
 
+# Returns
+
+A `DiagonalOperator` backed by `diag` and the configured update functions.
+
+# Errors
+
+Construction or update throws when a supplied diagonal update changes the
+leading dimension or returns an incompatible value.
+
 # Examples
+
+```julia
+using SciMLOperators
+
+D = DiagonalOperator([2.0, 3.0])
+D * [4.0, 5.0] == [8.0, 15.0]
+```
 """
 function DiagonalOperator(
         diag::AbstractVector;

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -181,6 +181,8 @@ throw.
 # Examples
 
 ```
+using SciMLOperators
+
 v = rand(4)
 u = rand(4)
 w = zeros(4)

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -163,8 +163,20 @@ $(UPDATE_COEFFS_WARNING)
 
 Lazy scalar algebra is defined for `AbstractSciMLScalarOperator`s. The
 interface supports lazy addition, subtraction, multiplication, and division.
-Updates must return a number with the intended scalar action; in-place scalar
-updates are not supported because numbers are immutable.
+Updates must return a number with the intended scalar action. The underlying
+number is immutable, but `ScalarOperator` itself is mutable, so
+`update_coefficients!` may replace its stored value and returns `nothing`.
+
+# Returns
+
+A `ScalarOperator` storing the current scalar value and the configured
+out-of-place update function.
+
+# Errors
+
+An update function that does not return a number, or a keyword that is not
+listed in `accepted_kwargs`, causes the corresponding update or evaluation to
+throw.
 
 # Examples
 

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -14,7 +14,35 @@ TensorProductOperator(A, B, C) = A ⊗ B ⊗ C
 ```
 where `M = size(B, 2)`, and `N = size(A, 2)`
 
-# Example
+# Arguments
+
+  - `A`: Left tensor factor, an `AbstractMatrix` or
+    `AbstractSciMLOperator`.
+  - `B`: Right tensor factor, an `AbstractMatrix` or
+    `AbstractSciMLOperator`.
+  - `ops...`: Additional factors for the variadic constructor.
+
+# Returns
+
+A lazy `TensorProductOperator` with the product size and action. Applying it
+does not form the full Kronecker matrix; `cache_operator` may be used before
+repeated in-place multiplication.
+
+# Interface Rules
+
+The factors must have compatible matrix dimensions for the requested action.
+The vector or batch input is interpreted using the tensor-product layout, and
+the output has the same batch shape with the product leading dimension.
+Use `convert(AbstractMatrix, L)` only when every factor supports eager
+materialization.
+
+# Errors
+
+Application throws a dimension error when the input does not match the
+product's leading dimension. Eager conversion throws when any factor lacks a
+concrete matrix representation.
+
+# Examples
 
 ```
 using SciMLOperators, LinearAlgebra

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -54,7 +54,7 @@ A_op = MatrixOperator(A)
 B_op = MatrixOperator(B)
 
 # Create tensor product operator
-T = A_op ⊗ B_op
+T = SciMLOperators.⊗(A_op, B_op)
 
 # Apply to a vector using the new interface
 v = rand(3*4)    # Action vector

--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -56,7 +56,7 @@ factorization for nonsquare or singular input.
 # Examples
 
 ```julia
-using SciMLOperators
+using LinearAlgebra, SciMLOperators
 
 W = StaticWOperator([2.0 0.0; 0.0 4.0])
 W \\ [2.0, 8.0]
@@ -260,7 +260,7 @@ give each consumer its own operator or track its own generation.
 # Examples
 
 ```julia
-using SciMLOperators
+using LinearAlgebra, SciMLOperators
 
 W = WOperator{true}(I, 0.5, [1.0 0.0; 0.0 2.0], zeros(2))
 jacobian_stale(W) # true until the consumer has initialized its cache
@@ -297,6 +297,8 @@ as a field. This function does not refactorize or otherwise update a cache.
 # Examples
 
 ```julia
+using LinearAlgebra, SciMLOperators
+
 J = [1.0 0.0; 0.0 2.0]
 W = WOperator{true}(I, 0.5, J, zeros(2))
 mark_jacobian_current!(W)
@@ -334,6 +336,8 @@ reduction. Calling it does not inspect `J` and does not refresh any cache.
 # Examples
 
 ```julia
+using LinearAlgebra, SciMLOperators
+
 W = WOperator{true}(I, 0.5, [1.0 0.0; 0.0 2.0], zeros(2))
 mark_jacobian_current!(W)
 @assert !jacobian_stale(W)

--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -1,3 +1,23 @@
+"""
+    AbstractWOperator{T} <: AbstractSciMLOperator{T}
+
+Developer-facing interface for operators representing the implicit-solver
+matrix ``W = J - MM / gamma``. This type is intentionally not exported and
+should not be used as a user-facing construction target.
+
+# Interface Rules
+
+A concrete subtype must provide `size`, matrix-like `*`, and `mul!` with the
+same shape and return-value rules as [`AbstractSciMLOperator`](@ref). It must
+also expose enough state for the implicit solver that owns it to update the
+Jacobian and mass-matrix actions. Define `isconvertible` and
+`convert(AbstractMatrix, W)` only when materialization is supported.
+
+If a consumer caches a Jacobian-dependent factorization, it should implement
+the [`jacobian_stale`](@ref), [`mark_jacobian_updated!`](@ref), and
+[`mark_jacobian_current!`](@ref) protocol or keep an equivalent private
+generation for its own subtype.
+"""
 abstract type AbstractWOperator{T} <: AbstractSciMLOperator{T} end
 
 """
@@ -20,7 +40,18 @@ $(FIELDS)
 `StaticWOperator` is a specialized helper for solver internals that need a
 fixed W-operator solve. It supports `Wstatic \\ v`; it does not participate in
 coefficient updates and should be reconstructed when the underlying matrix
-changes.
+changes. This is a developer-facing helper, not a general-purpose
+factorization type; user code should normally use `factorize` or a solver's
+documented linear-operator interface instead.
+
+# Returns
+
+`StaticWOperator(W, callinv) \\ v` returns the solution of `W * x = v`.
+
+# Errors
+
+The constructor and solve throw the same errors as the selected inverse or
+factorization for nonsquare or singular input.
 
 # Examples
 
@@ -60,14 +91,16 @@ $TYPEDEF
 
     WOperator{IIP}(mass_matrix, gamma, J, u[, jacvec])
 
-A linear operator that represents the W matrix of an ODEProblem, defined as
+A linear operator that represents the W matrix used by implicit ODE solvers,
+defined as
 
 ```math
-W = \\frac{1}{\\gamma}MM - J
+W = J - \\frac{1}{\\gamma}MM
 ```
 
-where `MM` is the mass matrix, `γ` is a scalar, and `J` is the Jacobian
-operator.
+where `MM` is the mass matrix, `gamma` is a scalar, and `J` is the Jacobian
+operator. The sign convention matches the matrix action implemented by
+`WOperator`: `W * x == J * x - (MM * x) / gamma`.
 
 # Arguments
 
@@ -82,6 +115,18 @@ operator.
 
 $(FIELDS)
 
+The fields have the following interface-relevant meanings:
+
+  - `mass_matrix`: The current mass-matrix action `MM`.
+  - `gamma`: The scalar in the mass-matrix term.
+  - `J`: The current Jacobian action.
+  - `jacvec`: Optional replacement for `J` in matrix-free `mul!` calls.
+  - `jac_stale`: Whether a consumer has been told that the Jacobian changed
+    since its last factorization.
+
+`_func_cache` and `_concrete_form` are implementation storage and are not
+part of the extension contract.
+
 # Interface Rules
 
 `WOperator` is part of the public solver-developer interface used by implicit
@@ -89,11 +134,29 @@ ODE solvers. It supports matrix-like `*`, `\\`, `mul!`, indexing, sizing, and
 concretization. Calling `update_coefficients!(W, u, p, t; gamma)` updates the
 Jacobian, mass matrix, optional Jacobian-vector operator, and stored `gamma`.
 Omitting `(u, p, t)` leaves those operators unchanged and only updates `gamma`
-when it is supplied.
+when it is supplied. The caller must call
+[`mark_jacobian_updated!`](@ref) after mutating the contents of `J` in place;
+the operator cannot observe that mutation automatically.
 
 `IIP` controls whether conversion reuses the internally stored concrete form
 as an in-place operator. The public contract is the mathematical action of
 `W`; downstream code should not depend on `_func_cache` or `_concrete_form`.
+This type is intended for solver developers extending the implicit-solver
+interface. End users should construct it only when a solver's documentation
+explicitly requests a `WOperator`.
+
+# Returns
+
+`WOperator{IIP}(mass_matrix, gamma, J, u, jacvec)` returns a mutable operator
+with the size of `J`. `*`, `mul!`, `\\`, and `concretize` use the current
+values of its fields and preserve the matrix action above.
+
+# Errors
+
+Construction or application can throw the dimension, conversion, or
+factorization errors raised by the supplied mass matrix and Jacobian. A
+matrix-free `J` or mass matrix cannot be materialized by
+`convert(AbstractMatrix, W)` unless both operands support that conversion.
 
 # Examples
 
@@ -170,12 +233,40 @@ Base.eltype(W::WOperator) = eltype(W.J)
 """
     jacobian_stale(W) -> Bool
 
-Whether `W`'s Jacobian has changed since a consumer last declared its factorization
-current. Conservatively `true` for anything that does not track it, so a caller that
-cannot ask simply refactorizes.
+Report whether the Jacobian-dependent state of `W` may have changed since a
+consumer last declared its cached factorization or reduction current.
 
-A solver caching a factorization of `W.J` across steps reads this: `false` means only
-`gamma` can have moved, and the cached factorization is still usable.
+# Arguments
+
+  - `W`: The object whose Jacobian-dependent state is being queried. For a
+    `WOperator`, this is its `jac_stale` flag. Other objects use the
+    conservative fallback.
+
+# Returns
+
+`true` means that a consumer must assume its Jacobian-dependent cache is
+stale. `false` means that the consumer may reuse that cache with respect to
+the Jacobian; it must still handle changes to `gamma` according to its own
+algorithm. The fallback returns `true`.
+
+# Interface Rules
+
+A solver that owns a factorization or reduction of `W.J` should query this
+predicate before reusing it and call [`mark_jacobian_current!`](@ref) only
+after refreshing its cache. The flag is shared by consumers, so a single
+`WOperator` must not be used as the cache source for independent consumers;
+give each consumer its own operator or track its own generation.
+
+# Examples
+
+```julia
+using SciMLOperators
+
+W = WOperator{true}(I, 0.5, [1.0 0.0; 0.0 2.0], zeros(2))
+jacobian_stale(W) # true until the consumer has initialized its cache
+mark_jacobian_current!(W)
+!jacobian_stale(W)
+```
 """
 jacobian_stale(W::WOperator) = W.jac_stale
 jacobian_stale(::Any) = true
@@ -183,12 +274,36 @@ jacobian_stale(::Any) = true
 """
     mark_jacobian_updated!(W) -> W
 
-Announce that the contents of `W`'s Jacobian have changed, invalidating any factorization
-of it a solver may be holding. A no-op for anything that does not track a Jacobian, so it
-is safe to call unconditionally.
+Announce that the contents of `W`'s Jacobian have changed, invalidating any
+Jacobian-dependent factorization or reduction a solver may be holding. A
+no-op for anything that does not track a Jacobian, so it is safe to call
+unconditionally after an in-place Jacobian update.
 
-Changing `gamma` is a *different* event and needs no announcement — it is visible in the
-field. This is only for an in-place write to `J`, which is not.
+# Arguments
+
+  - `W`: A `WOperator`, or any object for which the unconditional no-op
+    fallback is desired.
+
+# Returns
+
+The same object `W`. For a `WOperator`, its `jac_stale` flag is set to `true`.
+
+# Interface Rules
+
+Call this after the contents of `W.J` have been changed in place. Changing
+`gamma` is a different event and needs no announcement because it is visible
+as a field. This function does not refactorize or otherwise update a cache.
+
+# Examples
+
+```julia
+J = [1.0 0.0; 0.0 2.0]
+W = WOperator{true}(I, 0.5, J, zeros(2))
+mark_jacobian_current!(W)
+J .= 3I
+mark_jacobian_updated!(W)
+jacobian_stale(W) # true
+```
 """
 mark_jacobian_updated!(A) = A
 function mark_jacobian_updated!(W::WOperator)
@@ -199,8 +314,30 @@ end
 """
     mark_jacobian_current!(W) -> W
 
-Declare that the caller's factorization of `W.J` is up to date, clearing the flag
-[`mark_jacobian_updated!`](@ref) set. A no-op off the type.
+Declare that the caller's Jacobian-dependent cache is up to date, clearing
+the flag [`mark_jacobian_updated!`](@ref) set. A no-op off the type.
+
+# Arguments
+
+  - `W`: A `WOperator`, or any object for which the unconditional no-op
+    fallback is desired.
+
+# Returns
+
+The same object `W`. For a `WOperator`, its `jac_stale` flag is set to `false`.
+
+# Interface Rules
+
+Call this only after the consumer has actually refreshed its factorization or
+reduction. Calling it does not inspect `J` and does not refresh any cache.
+
+# Examples
+
+```julia
+W = WOperator{true}(I, 0.5, [1.0 0.0; 0.0 2.0], zeros(2))
+mark_jacobian_current!(W)
+@assert !jacobian_stale(W)
+```
 
 !!! warning "One consumer per operator"
     This is a single shared flag, not a per-consumer generation count. Two solvers caching

--- a/src/woperator.jl
+++ b/src/woperator.jl
@@ -7,10 +7,13 @@ should not be used as a user-facing construction target.
 
 # Interface Rules
 
-A concrete subtype must provide `size`, matrix-like `*`, and `mul!` with the
-same shape and return-value rules as [`AbstractSciMLOperator`](@ref). It must
-also expose enough state for the implicit solver that owns it to update the
-Jacobian and mass-matrix actions. Define `isconvertible` and
+A concrete subtype must provide `size`, matrix-like `*`, and
+`mul!(out, W, x)` with the same shape and return-value rules as
+[`AbstractSciMLOperator`](@ref). If `has_mul!(W)` is true, it must also
+provide `mul!(out, W, x, alpha, beta)` implementing
+`out = alpha * (W * x) + beta * out`, and both mutating methods must return
+`out`. It must also expose enough state for the implicit solver that owns it
+to update the Jacobian and mass-matrix actions. Define `isconvertible` and
 `convert(AbstractMatrix, W)` only when materialization is supported.
 
 If a consumer caches a Jacobian-dependent factorization, it should implement

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -64,6 +64,7 @@ end
 SciMLOperators.islinear(::GenericDiagonalOperator) = true
 SciMLOperators.isconvertible(::GenericDiagonalOperator) = true
 SciMLOperators.has_concretization(::GenericDiagonalOperator) = true
+SciMLOperators.isconstant(::GenericDiagonalOperator) = false
 
 function SciMLOperators.update_coefficients(
         L::GenericDiagonalOperator, u, p, t; scale = p
@@ -86,7 +87,7 @@ end
     @test size(L) == (2, 2)
     @test issquare(L)
     @test islinear(L)
-    @test isconstant(L)
+    @test !isconstant(L)
     @test isconvertible(L)
     @test has_concretization(L)
     @test has_mul(L)
@@ -111,4 +112,54 @@ end
 
     L(w, v, nothing, 3.0, 0.0, 2.0, 0.5)
     @test w == [56.0, 105.0]
+end
+
+mutable struct GenericScalarOperator <: SciMLOperators.AbstractSciMLScalarOperator{Float64}
+    value::Float64
+end
+
+Base.convert(::Type{Number}, L::GenericScalarOperator) = L.value
+SciMLOperators.isconstant(::GenericScalarOperator) = false
+SciMLOperators.has_ldiv(L::GenericScalarOperator) = !iszero(L.value)
+SciMLOperators.has_ldiv!(L::GenericScalarOperator) = !iszero(L.value)
+
+function SciMLOperators.update_coefficients(
+        L::GenericScalarOperator, u, p, t; scale = p
+    )
+    return GenericScalarOperator(scale)
+end
+
+function SciMLOperators.update_coefficients!(
+        L::GenericScalarOperator, u, p, t; scale = p
+    )
+    L.value = scale
+    return nothing
+end
+
+@testset "AbstractSciMLScalarOperator generic interface" begin
+    L = GenericScalarOperator(2.0)
+    v = [4.0, 5.0]
+    w = [7.0, 11.0]
+
+    @test size(L) == ()
+    @test islinear(L)
+    @test !isconstant(L)
+    @test has_mul(L)
+    @test has_mul!(L)
+    @test has_ldiv(L)
+    @test has_ldiv!(L)
+    @test has_concretization(L)
+    @test concretize(L) == 2.0
+    @test L * v == [8.0, 10.0]
+    @test mul!(copy(w), L, v) == [8.0, 10.0]
+
+    updated = update_coefficients(L, nothing, 3.0, 0.0)
+    @test updated !== L
+    @test updated * v == [12.0, 15.0]
+    @test L(v, nothing, 4.0, 0.0) == [16.0, 20.0]
+
+    @test update_coefficients!(L, nothing, 5.0, 0.0) === nothing
+    @test L * v == [20.0, 25.0]
+    L(w, v, nothing, 3.0, 0.0)
+    @test w == [12.0, 15.0]
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -126,6 +126,12 @@ function LinearAlgebra.mul!(w::AbstractVector, W::GenericWOperator, v::AbstractV
     mul!(w, W.matrix, v)
     return w
 end
+function LinearAlgebra.mul!(
+        w::AbstractVector, W::GenericWOperator, v::AbstractVector, α, β
+    )
+    mul!(w, W.matrix, v, α, β)
+    return w
+end
 SciMLOperators.jacobian_stale(W::GenericWOperator) = W.stale
 function SciMLOperators.mark_jacobian_updated!(W::GenericWOperator)
     W.stale = true
@@ -142,9 +148,12 @@ end
     w = zeros(2)
 
     @test size(W) == (2, 2)
+    @test has_mul!(W)
     @test W * v == [8.0, 15.0]
     @test mul!(w, W, v) === w
     @test w == [8.0, 15.0]
+    @test mul!(w, W, v, 2.0, 0.5) === w
+    @test w == [20.0, 37.5]
     @test jacobian_stale(W)
     @test mark_jacobian_current!(W) === W
     @test !jacobian_stale(W)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -4,6 +4,7 @@ using LinearAlgebra, SciMLOperators, Test
     owner_public_names = (
         :AbstractSciMLOperator,
         :AbstractSciMLScalarOperator,
+        :AbstractWOperator,
         :ScaledOperator,
         :AddedOperator,
         :ComposedOperator,
@@ -112,6 +113,43 @@ end
 
     L(w, v, nothing, 3.0, 0.0, 2.0, 0.5)
     @test w == [56.0, 105.0]
+end
+
+mutable struct GenericWOperator <: SciMLOperators.AbstractWOperator{Float64}
+    matrix::Matrix{Float64}
+    stale::Bool
+end
+
+Base.size(W::GenericWOperator) = size(W.matrix)
+Base.:*(W::GenericWOperator, v::AbstractVector) = W.matrix * v
+function LinearAlgebra.mul!(w::AbstractVector, W::GenericWOperator, v::AbstractVector)
+    mul!(w, W.matrix, v)
+    return w
+end
+SciMLOperators.jacobian_stale(W::GenericWOperator) = W.stale
+function SciMLOperators.mark_jacobian_updated!(W::GenericWOperator)
+    W.stale = true
+    return W
+end
+function SciMLOperators.mark_jacobian_current!(W::GenericWOperator)
+    W.stale = false
+    return W
+end
+
+@testset "AbstractWOperator generic interface" begin
+    W = GenericWOperator([2.0 0.0; 0.0 3.0], true)
+    v = [4.0, 5.0]
+    w = zeros(2)
+
+    @test size(W) == (2, 2)
+    @test W * v == [8.0, 15.0]
+    @test mul!(w, W, v) === w
+    @test w == [8.0, 15.0]
+    @test jacobian_stale(W)
+    @test mark_jacobian_current!(W) === W
+    @test !jacobian_stale(W)
+    @test mark_jacobian_updated!(W) === W
+    @test jacobian_stale(W)
 end
 
 mutable struct GenericScalarOperator <: SciMLOperators.AbstractSciMLScalarOperator{Float64}


### PR DESCRIPTION
Draft: ignore until reviewed by @ChrisRackauckas.

## What changed

This updates the existing Jacobian-staleness documentation PR into a focused public/developer interface documentation change:

- Documents the required `AbstractSciMLOperator` and `AbstractSciMLScalarOperator` contracts: size, `*`, `mul!`, scaled multiplication, state updates, caching, keyword forwarding, traits, conversion, and batch shapes.
- Documents `AbstractWOperator` as a qualified solver-developer interface and fully documents the `WOperator` Jacobian-staleness protocol, arguments, returns, errors, and examples.
- Adds the new staleness methods to the rendered interface page and repairs invalid examples in the abstract, matrix, scalar, and tensor docstrings.
- Adds a generic scalar operator test and corrects the generic stateful diagonal test to explicitly report `isconstant == false`.
- Adds `Arguments`, `Returns`, `Errors`, `Interface Rules`, and `Examples` sections to the central update, cache, trait, constructor, and developer-hook docs.

No compat changes, implementation behavior changes, test suppression, doctest suppression, or repo-specific QA overrides are included.

## Verification

Run locally from the PR checkout:

- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: `QA/qa.jl | 20 pass | 20 total` with SciMLTesting 2.10.0 resolving from the package test environment's SciMLTesting `2.4` floor.
- `GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed all Core groups, including `Core/interface.jl | 118 pass | 118 total`; the suite reports two broken tests reported by the suite (one each in matrix and scalar) and no failures or errors.
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); include("docs/make.jl")'`: Documenter doctests, cross-references, missing-doc checks, and HTML rendering passed. Deployment was skipped because this was a local build.
- Runic `Runic.format_string(...; filemode=true)` comparison on all changed Julia files: no format drift.
- `typos` on all changed source, test, and docs files: passed.
- `git diff --check`: passed.

## Downstream context

The earlier metadata-only [SciMLTesting declaration PR](https://github.com/SciML/SciMLOperators.jl/pull/420) failed its documentation check because it did not contain the documentation commit; this PR now contains those rendered entries. Its LinearSolve downstream failure is unrelated to this documentation change: the recorded failure is in LinearSolve's randomized `GenericLU` naive back-solve test at `downstream/test/Core/genericlu_naive_ldiv.jl:122`, with 503 passes and 1 failure. This PR does not change LinearSolve or the operator solve implementation.

Follow-up commit `21addd8` also makes `AbstractWOperator` explicitly public and adds a generic W-operator interface test covering size, multiplication, `mul!`, and Jacobian staleness transitions. The final local Core result is `Core/interface.jl | 118 pass | 118 total`.