### PR TITLE
compat: declare SciMLTesting test dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,4 +28,8 @@ LinearAlgebra = "1.10"
 LoopVectorization = "0.12"
 SciMLPublic = "1"
 SparseArrays = "1.10"
+SciMLTesting = "2.10"
 julia = "1.10"
+
+[extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"


### PR DESCRIPTION
Please ignore this draft until reviewed by @ChrisRackauckas.

## Summary

The package-level `Project.toml` did not declare the SciMLTesting test dependency, although the repository test, QA, and downstream environments already use SciMLTesting. Add the package-level `SciMLTesting = "2.10"` compatibility bound and test extra so the released package manifest is included in the SciMLTesting QA census. This is metadata-only and does not change runtime behavior or QA configuration.

## Verification

- `GROUP=QA timeout 3600 julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: `QA/qa.jl | 20 pass | 20 total`\n- TOML parse and compat/UUID assertions: passed\n- `typos Project.toml`: passed\n- `git diff --check`: passed\n\nNo hosted CI was waited on for this draft.