### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLOperators"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.27.0"
+version = "1.28.0"
 authors = ["Vedant Puri <vedantpuri@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Version bumps only -- no source changes.

Each package below has `src/` changes since its last registered version (verified by comparing the registry's recorded `git-tree-sha1` for that version against the current tree), but its `Project.toml` version still equals the registered one, so there is nothing to register.

Increment is minor, which is a valid standard increment under the General [sequential version number](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) guideline.

- SciMLOperators 1.27.0 -> 1.28.0