### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,85 @@
+using SciMLOperators, BenchmarkTools
+using LinearAlgebra, SparseArrays, StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+N = 100
+v = rand(rng, N)
+w = rand(rng, N)
+u_state = zeros(N)
+A = rand(rng, N, N)
+As = sparse(A)
+d = rand(rng, N)
+
+# =============================================================================
+# Operator construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+f_oop(vv, u, p, t) = A * vv
+f_iip(ww, vv, u, p, t) = mul!(ww, A, vv)
+
+SUITE["construct"]["MatrixOperator"] = @benchmarkable MatrixOperator($A)
+SUITE["construct"]["DiagonalOperator"] = @benchmarkable DiagonalOperator($d)
+SUITE["construct"]["ScalarOperator"] = @benchmarkable ScalarOperator(2.0)
+SUITE["construct"]["FunctionOperator"] = @benchmarkable FunctionOperator(
+    $f_iip, $v, $w; u = $u_state, p = nothing, t = 0.0
+)
+
+# =============================================================================
+# Application: L(v, u, p, t) out-of-place, L(w, v, u, p, t) in-place
+# =============================================================================
+
+SUITE["apply"] = BenchmarkGroup()
+
+L = MatrixOperator(A)
+Ls = MatrixOperator(As)
+Ld = DiagonalOperator(d)
+α = ScalarOperator(2.0)
+
+SUITE["apply"]["dense_matvec"] = @benchmarkable $L * $v
+SUITE["apply"]["sparse_matvec"] = @benchmarkable $Ls * $v
+SUITE["apply"]["diagonal_matvec"] = @benchmarkable $Ld * $v
+SUITE["apply"]["oop_eval"] = @benchmarkable $L($v, $u_state, nothing, 0.0)
+SUITE["apply"]["iip_eval"] = @benchmarkable $L($w, $v, $u_state, nothing, 0.0)
+
+# =============================================================================
+# Operator algebra
+# =============================================================================
+
+SUITE["algebra"] = BenchmarkGroup()
+
+SUITE["algebra"]["compose"] = @benchmarkable $L * $L
+SUITE["algebra"]["add"] = @benchmarkable $L + $Ld
+SUITE["algebra"]["scalar_mul"] = @benchmarkable $α * $L
+
+Lcomp = L * Ld
+SUITE["algebra"]["composed_apply"] = @benchmarkable $Lcomp($v, $u_state, nothing, 0.0)
+
+F = FunctionOperator(f_iip, v, w; u = u_state, p = nothing, t = 0.0)
+SUITE["algebra"]["function_operator_apply"] = @benchmarkable $F(
+    $w, $v, $u_state, nothing, 0.0
+)
+
+Lsum = 2L + Ld
+SUITE["algebra"]["sum_apply"] = @benchmarkable $Lsum($v, $u_state, nothing, 0.0)
+
+# =============================================================================
+# Tensor product
+# =============================================================================
+
+SUITE["tensor"] = BenchmarkGroup()
+
+A1 = rand(rng, 20, 20)
+A2 = rand(rng, 30, 30)
+L1 = MatrixOperator(A1)
+L2 = MatrixOperator(A2)
+
+SUITE["tensor"]["construct"] = @benchmarkable TensorProductOperator($L1, $L2)
+T = TensorProductOperator(L1, L2)
+v2 = rand(rng, 600)
+u2 = zeros(600)
+SUITE["tensor"]["apply"] = @benchmarkable $T * $v2
+SUITE["tensor"]["oop_eval"] = @benchmarkable $T($v2, $u2, nothing, 0.0)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~11s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~11s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md