### PR TITLE
Call `Base.kron` in the SparseArrays extension

### DIFF
--- a/ext/SciMLOperatorsSparseArraysExt.jl
+++ b/ext/SciMLOperatorsSparseArraysExt.jl
@@ -12,7 +12,7 @@ SparseArrays.sparse(L::SciMLOperators.AddedOperator) = sum(sparse, L.ops)
 SparseArrays.sparse(L::SciMLOperators.ComposedOperator) = prod(sparse, L.ops)
 SparseArrays.sparse(L::SciMLOperators.IdentityOperator) = sparse(LinearAlgebra.I, size(L))
 function SparseArrays.sparse(L::SciMLOperators.TensorProductOperator)
-    return LinearAlgebra.kron(sparse.(L.ops)...)
+    return Base.kron(sparse.(L.ops)...)
 end
 function SparseArrays.sparse(L::SciMLOperators.BlockDiagonalOperator)
     return SparseArrays.blockdiag(sparse.(L.ops)...)


### PR DESCRIPTION
## Summary

The QA job on the `julia '1'` lane (Julia 1.13.0) fails the ExplicitImports public-access checks because `SciMLOperatorsSparseArraysExt` calls `LinearAlgebra.kron`, while `kron`'s owner is `Base` and it is no longer public in `LinearAlgebra` on 1.13.

Failing run: https://github.com/SciML/SciMLOperators.jl/actions/runs/34655484919

`Base.kron` exists back to Julia 1.10, so behavior on older versions is identical.

Note: this is one of two QA failures on that run; the other is a Julia 1.13 method ambiguity around `FunctionOperator`'s varargs `mul!`, fixed separately in #433 so this stays a mechanical import change. The QA lane stays red on either PR alone — both need to merge for it to go green.

## Test plan

- [x] ExplicitImports checks pass on Julia 1.13.0 (they errored in CI on the unfixed code)
- [ ] CI

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max). Session: local session, `/home/crackauc/.local/share/devin/cli/sessions.db`
