### PR TITLE
Disambiguate `mul!` for out-of-place `FunctionOperator`

### DIFF
--- a/src/func.jl
+++ b/src/func.jl
@@ -954,13 +954,21 @@ function LinearAlgebra.mul!(w::AbstractArray, L::FunctionOperator{true}, v::Abst
 end
 
 function LinearAlgebra.mul!(
-        w::AbstractArray, L::FunctionOperator{false}, v::AbstractArray,
-        args...
+        w::AbstractArray, L::FunctionOperator{false}, v::AbstractArray
     )
     _sizecheck(L, v, w)
     V, W, vec_output = _unvec(L, v, w)
     W .= L.op(V, L.u, L.p, L.t; L.traits.kwargs...)
     return vec_output ? vec(W) : W
+end
+
+function LinearAlgebra.mul!(
+        w::AbstractArray, L::FunctionOperator{false}, v::AbstractArray, α, β
+    )
+    _sizecheck(L, v, w)
+    V, W, _ = _unvec(L, v, w)
+    W .= α .* L.op(V, L.u, L.p, L.t; L.traits.kwargs...) .+ β .* W
+    return w
 end
 
 function LinearAlgebra.mul!(

--- a/test/func.jl
+++ b/test/func.jl
@@ -199,6 +199,9 @@ end
     w = copy(v)
     @test α * _mul(A, v) + β * w ≈ mul!(w, op2, v, α, β)
 
+    w = copy(v)
+    @test α * _mul(A, v) + β * w ≈ mul!(w, op1, v, α, β)
+
     w = rand(N, K)
     @test _div(A, w) ≈ op1 \ w ≈ ldiv!(v, op2, w)
     w = copy(v)


### PR DESCRIPTION
## Summary

Julia 1.13 adds public `mul!` methods taking BLAS-style transform arguments (`mul!(C, tA, A, B, α, β)` and the one-transform variant). The varargs signature `mul!(w, L::FunctionOperator{false}, v, args...)` is now ambiguous with them, and Aqua's ambiguity check fails the QA job on the `julia '1'` lane:

- https://github.com/SciML/SciMLOperators.jl/actions/runs/34655484919

This replaces the varargs signature with the two arities actually used: three-argument (unchanged) and five-argument `mul!(w, L, v, α, β)` computing `w ← α(Lv) + βw`, matching the docstring and the `FunctionOperator{true, oop, false}` method (which does the same via `axpby!`).

The varargs method previously accepted `α, β` but **silently ignored them** — a latent correctness bug independent of the ambiguity. Verified:

- Unfixed code: `mul!(w, L, v, 2.0, 3.0)` returns `[2.0, 4.0, 6.0]` (= `L*v`)
- Fixed: returns `[7.0, 11.0, 15.0]` (= `2·(2v) + 3w`)

A regression test for the OOP five-argument path is included — the existing suite only covered the in-place operator. The added test fails on the old code and passes now.

Companion to #432 (the `Base.kron` import fix) — both are needed for the QA job to go green, kept as separate PRs since this one changes behavior.

## Test plan

- [x] `test/qa/qa.jl` passes 20/20 on Julia 1.13.0 (Aqua ambiguity check no longer reports the signatures; it errored in CI on the unfixed code)
- [x] `test/func.jl` — all FunctionOperator testsets pass, including the new OOP 5-arg `mul!` assertion
- [ ] CI

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max). Session: local session, `/home/crackauc/.local/share/devin/cli/sessions.db`